### PR TITLE
feat: add comprehensive ARIA accessibility attributes to modal components

### DIFF
--- a/client/src/components/modals/AssignmentModalNew.tsx
+++ b/client/src/components/modals/AssignmentModalNew.tsx
@@ -227,8 +227,8 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
         <div className="py-4">
 
           {hasErrors && (
-            <Alert variant="destructive" className="mb-4">
-              <AlertTriangle className="h-4 w-4" />
+            <Alert variant="destructive" className="mb-4" role="alert" aria-live="assertive">
+              <AlertTriangle className="h-4 w-4" aria-hidden="true" />
               <AlertDescription>
                 Please fix the errors below before submitting.
               </AlertDescription>
@@ -238,9 +238,15 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
           <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <Label htmlFor="project_id">Project *</Label>
+              <Label htmlFor="project_id">Project <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Select value={formData.project_id} onValueChange={(value) => handleChange('project_id', value)}>
-                <SelectTrigger className={errors.project_id ? 'border-red-500' : ''}>
+                <SelectTrigger
+                  id="project_id"
+                  className={errors.project_id ? 'border-red-500' : ''}
+                  aria-required="true"
+                  aria-invalid={!!errors.project_id}
+                  aria-describedby={errors.project_id ? 'project_id-error' : undefined}
+                >
                   <SelectValue placeholder="Select project" />
                 </SelectTrigger>
                 <SelectContent>
@@ -251,13 +257,19 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
                   ))}
                 </SelectContent>
               </Select>
-              {errors.project_id && <span className="text-sm text-red-500">{errors.project_id}</span>}
+              {errors.project_id && <span id="project_id-error" className="text-sm text-red-500" role="alert">{errors.project_id}</span>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="person_id">Person *</Label>
+              <Label htmlFor="person_id">Person <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Select value={formData.person_id} onValueChange={(value) => handleChange('person_id', value)}>
-                <SelectTrigger className={errors.person_id ? 'border-red-500' : ''}>
+                <SelectTrigger
+                  id="person_id"
+                  className={errors.person_id ? 'border-red-500' : ''}
+                  aria-required="true"
+                  aria-invalid={!!errors.person_id}
+                  aria-describedby={errors.person_id ? 'person_id-error' : undefined}
+                >
                   <SelectValue placeholder="Select person" />
                 </SelectTrigger>
                 <SelectContent>
@@ -268,30 +280,36 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
                   ))}
                 </SelectContent>
               </Select>
-              {errors.person_id && <span className="text-sm text-red-500">{errors.person_id}</span>}
+              {errors.person_id && <span id="person_id-error" className="text-sm text-red-500" role="alert">{errors.person_id}</span>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="role_id">Role *</Label>
+              <Label htmlFor="role_id">Role <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Select value={formData.role_id} onValueChange={(value) => handleChange('role_id', value)}>
-                <SelectTrigger className={errors.role_id ? 'border-red-500' : ''}>
+                <SelectTrigger
+                  id="role_id"
+                  className={errors.role_id ? 'border-red-500' : ''}
+                  aria-required="true"
+                  aria-invalid={!!errors.role_id}
+                  aria-describedby={errors.role_id ? 'role_id-error' : undefined}
+                >
                   <SelectValue placeholder="Select role" />
                 </SelectTrigger>
                 <SelectContent>
-                  {roles?.map((role: any) => (
+                  {Array.isArray(roles) && roles.map((role: any) => (
                     <SelectItem key={role.id} value={role.id}>
                       {role.name}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              {errors.role_id && <span className="text-sm text-red-500">{errors.role_id}</span>}
+              {errors.role_id && <span id="role_id-error" className="text-sm text-red-500" role="alert">{errors.role_id}</span>}
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="phase_id">Phase</Label>
               <Select value={formData.phase_id} onValueChange={(value) => handleChange('phase_id', value)}>
-                <SelectTrigger>
+                <SelectTrigger id="phase_id">
                   <SelectValue placeholder="Select phase (optional)" />
                 </SelectTrigger>
                 <SelectContent>
@@ -305,31 +323,37 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="start_date">Start Date *</Label>
+              <Label htmlFor="start_date">Start Date <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Input
                 type="date"
                 id="start_date"
                 value={formData.start_date}
                 onChange={(e) => handleChange('start_date', e.target.value)}
                 className={errors.start_date ? 'border-red-500' : ''}
+                aria-required="true"
+                aria-invalid={!!errors.start_date}
+                aria-describedby={errors.start_date ? 'start_date-error' : undefined}
               />
-              {errors.start_date && <span className="text-sm text-red-500">{errors.start_date}</span>}
+              {errors.start_date && <span id="start_date-error" className="text-sm text-red-500" role="alert">{errors.start_date}</span>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="end_date">End Date *</Label>
+              <Label htmlFor="end_date">End Date <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Input
                 type="date"
                 id="end_date"
                 value={formData.end_date}
                 onChange={(e) => handleChange('end_date', e.target.value)}
                 className={errors.end_date ? 'border-red-500' : ''}
+                aria-required="true"
+                aria-invalid={!!errors.end_date}
+                aria-describedby={errors.end_date ? 'end_date-error' : undefined}
               />
-              {errors.end_date && <span className="text-sm text-red-500">{errors.end_date}</span>}
+              {errors.end_date && <span id="end_date-error" className="text-sm text-red-500" role="alert">{errors.end_date}</span>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="allocation_percentage">Allocation % *</Label>
+              <Label htmlFor="allocation_percentage">Allocation % <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Input
                 type="number"
                 id="allocation_percentage"
@@ -338,14 +362,17 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
                 min="1"
                 max="100"
                 className={errors.allocation_percentage ? 'border-red-500' : ''}
+                aria-required="true"
+                aria-invalid={!!errors.allocation_percentage}
+                aria-describedby={errors.allocation_percentage ? 'allocation_percentage-error' : undefined}
               />
-              {errors.allocation_percentage && <span className="text-sm text-red-500">{errors.allocation_percentage}</span>}
+              {errors.allocation_percentage && <span id="allocation_percentage-error" className="text-sm text-red-500" role="alert">{errors.allocation_percentage}</span>}
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="assignment_date_mode">Date Mode</Label>
               <Select value={formData.assignment_date_mode} onValueChange={(value: any) => handleChange('assignment_date_mode', value)}>
-                <SelectTrigger>
+                <SelectTrigger id="assignment_date_mode">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -365,7 +392,9 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
               onChange={(e) => handleChange('notes', e.target.value)}
               rows={3}
               placeholder="Additional notes about this assignment..."
+              aria-describedby="notes-description"
             />
+            <span id="notes-description" className="sr-only">Optional additional notes about this assignment</span>
           </div>
 
           <div className="flex items-center space-x-2">
@@ -373,8 +402,10 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
               id="billable"
               checked={formData.billable}
               onCheckedChange={(checked) => handleChange('billable', checked === true)}
+              aria-describedby="billable-description"
             />
             <Label htmlFor="billable">Billable assignment</Label>
+            <span id="billable-description" className="sr-only">Mark this assignment as billable to client</span>
           </div>
 
             <DialogFooter>

--- a/client/src/components/modals/LocationModal.tsx
+++ b/client/src/components/modals/LocationModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../ui/dialog';
 import { Button } from '../ui/button';
@@ -90,18 +91,23 @@ export function LocationModal({ location, onSave, onCancel }: LocationModalProps
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{location ? 'Edit Location' : 'Add Location'}</DialogTitle>
+          <DialogDescription>
+            {location
+              ? 'Update the location details below.'
+              : 'Fill in the information to create a new location.'}
+          </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-4">
             {error && (
-              <Alert variant="destructive">
+              <Alert variant="destructive" role="alert" aria-live="assertive">
                 <AlertDescription>{error}</AlertDescription>
               </Alert>
             )}
 
             <div className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="name">Name *</Label>
+                <Label htmlFor="name">Name <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
                 <Input
                   id="name"
                   type="text"
@@ -109,6 +115,7 @@ export function LocationModal({ location, onSave, onCancel }: LocationModalProps
                   onChange={(e) => handleChange('name', e.target.value)}
                   placeholder="e.g., New York City, Remote, London"
                   required
+                  aria-required="true"
                 />
               </div>
 

--- a/client/src/components/modals/PersonModal.tsx
+++ b/client/src/components/modals/PersonModal.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../ui/dialog';
 import { Button } from '../ui/button';
@@ -243,17 +244,17 @@ export const PersonModal: React.FC<PersonModalProps> = ({
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit Person' : 'Add New Person'}</DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'Update the person\'s information below.'
+              : 'Fill in the information to create a new person.'}
+          </DialogDescription>
         </DialogHeader>
         <div className="py-4">
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-            {isEditing 
-              ? 'Update the person\'s information below.' 
-              : 'Fill in the information to create a new person.'}
-          </p>
 
           {hasErrors && (
-            <Alert variant="destructive" className="mb-6">
-              <AlertCircle className="h-4 w-4" />
+            <Alert variant="destructive" className="mb-6" role="alert" aria-live="assertive">
+              <AlertCircle className="h-4 w-4" aria-hidden="true" />
               <AlertDescription>
                 Please fix the errors below before submitting.
               </AlertDescription>
@@ -263,19 +264,22 @@ export const PersonModal: React.FC<PersonModalProps> = ({
           <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="name">Name *</Label>
+              <Label htmlFor="name">Name <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => handleChange('name', e.target.value)}
                 placeholder="Enter full name"
                 className={errors.name ? 'border-destructive' : ''}
+                aria-required="true"
+                aria-invalid={!!errors.name}
+                aria-describedby={errors.name ? 'name-error' : undefined}
               />
-              {errors.name && <p className="text-sm text-destructive">{errors.name}</p>}
+              {errors.name && <p id="name-error" className="text-sm text-destructive" role="alert">{errors.name}</p>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="email">Email *</Label>
+              <Label htmlFor="email">Email <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Input
                 type="email"
                 id="email"
@@ -283,8 +287,11 @@ export const PersonModal: React.FC<PersonModalProps> = ({
                 onChange={(e) => handleChange('email', e.target.value)}
                 placeholder="Enter email address"
                 className={errors.email ? 'border-destructive' : ''}
+                aria-required="true"
+                aria-invalid={!!errors.email}
+                aria-describedby={errors.email ? 'email-error' : undefined}
               />
-              {errors.email && <p className="text-sm text-destructive">{errors.email}</p>}
+              {errors.email && <p id="email-error" className="text-sm text-destructive" role="alert">{errors.email}</p>}
             </div>
 
             <div className="space-y-2">
@@ -321,7 +328,7 @@ export const PersonModal: React.FC<PersonModalProps> = ({
             <div className="space-y-2">
               <Label htmlFor="location_id">Location</Label>
               <Select value={formData.location_id || 'none'} onValueChange={(value) => handleChange('location_id', value === 'none' ? '' : value)}>
-                <SelectTrigger>
+                <SelectTrigger id="location_id">
                   <SelectValue placeholder="Select location" />
                 </SelectTrigger>
                 <SelectContent>
@@ -336,12 +343,18 @@ export const PersonModal: React.FC<PersonModalProps> = ({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="primary_person_role_id">Primary Role *</Label>
-              <Select 
-                value={formData.primary_person_role_id} 
+              <Label htmlFor="primary_person_role_id">Primary Role <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
+              <Select
+                value={formData.primary_person_role_id}
                 onValueChange={(value) => handleChange('primary_person_role_id', value)}
               >
-                <SelectTrigger className={errors.primary_person_role_id ? 'border-destructive' : ''}>
+                <SelectTrigger
+                  id="primary_person_role_id"
+                  className={errors.primary_person_role_id ? 'border-destructive' : ''}
+                  aria-required="true"
+                  aria-invalid={!!errors.primary_person_role_id}
+                  aria-describedby={errors.primary_person_role_id ? 'primary_person_role_id-error' : undefined}
+                >
                   <SelectValue placeholder="Select primary role" />
                 </SelectTrigger>
                 <SelectContent>
@@ -352,13 +365,13 @@ export const PersonModal: React.FC<PersonModalProps> = ({
                   )) : []}
                 </SelectContent>
               </Select>
-              {errors.primary_person_role_id && <p className="text-sm text-destructive">{errors.primary_person_role_id}</p>}
+              {errors.primary_person_role_id && <p id="primary_person_role_id-error" className="text-sm text-destructive" role="alert">{errors.primary_person_role_id}</p>}
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="supervisor_id">Supervisor</Label>
               <Select value={formData.supervisor_id || 'none'} onValueChange={(value) => handleChange('supervisor_id', value === 'none' ? '' : value)}>
-                <SelectTrigger>
+                <SelectTrigger id="supervisor_id">
                   <SelectValue placeholder="Select supervisor" />
                 </SelectTrigger>
                 <SelectContent>
@@ -375,7 +388,7 @@ export const PersonModal: React.FC<PersonModalProps> = ({
             <div className="space-y-2">
               <Label htmlFor="worker_type">Worker Type</Label>
               <Select value={formData.worker_type} onValueChange={(value) => handleChange('worker_type', value)}>
-                <SelectTrigger>
+                <SelectTrigger id="worker_type">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -437,7 +450,7 @@ export const PersonModal: React.FC<PersonModalProps> = ({
             <div className="space-y-2">
               <Label htmlFor="status">Status</Label>
               <Select value={formData.status} onValueChange={(value) => handleChange('status', value)}>
-                <SelectTrigger>
+                <SelectTrigger id="status">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/client/src/components/modals/PersonRoleModal.tsx
+++ b/client/src/components/modals/PersonRoleModal.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../ui/dialog';
 import { Button } from '../ui/button';
@@ -136,23 +137,23 @@ export default function PersonRoleModal({
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{editingRole ? 'Edit Role' : 'Add Role'}</DialogTitle>
+          <DialogDescription>
+            {editingRole
+              ? 'Update the role details for this person.'
+              : 'Add a new role for this person.'}
+          </DialogDescription>
         </DialogHeader>
         <div className="py-4">
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-            {editingRole 
-              ? 'Update the role details for this person.' 
-              : 'Add a new role for this person.'}
-          </p>
 
           <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-2">
-            <Label htmlFor="role_id">Role *</Label>
-            <Select 
-              value={formData.role_id} 
+            <Label htmlFor="role_id">Role <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
+            <Select
+              value={formData.role_id}
               onValueChange={(value) => handleInputChange('role_id', value)}
               disabled={isSubmitting || rolesLoading}
             >
-              <SelectTrigger>
+              <SelectTrigger id="role_id" aria-required="true">
                 <SelectValue placeholder="Select a role..." />
               </SelectTrigger>
               <SelectContent>
@@ -166,13 +167,13 @@ export default function PersonRoleModal({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="proficiency_level">Proficiency Level *</Label>
-            <Select 
-              value={formData.proficiency_level} 
+            <Label htmlFor="proficiency_level">Proficiency Level <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
+            <Select
+              value={formData.proficiency_level}
               onValueChange={(value) => handleInputChange('proficiency_level', value)}
               disabled={isSubmitting}
             >
-              <SelectTrigger>
+              <SelectTrigger id="proficiency_level" aria-required="true">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -192,12 +193,13 @@ export default function PersonRoleModal({
                 checked={formData.is_primary}
                 onCheckedChange={(checked) => handleInputChange('is_primary', checked)}
                 disabled={isSubmitting}
+                aria-describedby="is_primary-description"
               />
               <Label htmlFor="is_primary" className="cursor-pointer">
                 Set as Primary Role
               </Label>
             </div>
-            <p className="text-sm text-muted-foreground">
+            <p id="is_primary-description" className="text-sm text-muted-foreground">
               If checked, this role will become the person's primary role.
             </p>
           </div>

--- a/client/src/components/modals/ProjectModal.tsx
+++ b/client/src/components/modals/ProjectModal.tsx
@@ -15,6 +15,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../ui/dialog';
 
@@ -247,17 +248,17 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit Project' : 'Add New Project'}</DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'Update the project details below.'
+              : 'Fill in the information to create a new project.'}
+          </DialogDescription>
         </DialogHeader>
         <div className="py-4">
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-            {isEditing 
-              ? 'Update the project details below.' 
-              : 'Fill in the information to create a new project.'}
-          </p>
 
           {hasErrors && (
-            <Alert variant="destructive" className="mb-6">
-              <AlertCircle className="h-4 w-4" />
+            <Alert variant="destructive" className="mb-6" role="alert" aria-live="assertive">
+              <AlertCircle className="h-4 w-4" aria-hidden="true" />
               <AlertDescription>
                 Please fix the errors below before submitting.
               </AlertDescription>
@@ -267,21 +268,30 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
           <form onSubmit={handleSubmit} className="space-y-6">
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="name">Project Name *</Label>
+              <Label htmlFor="name">Project Name <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => handleChange('name', e.target.value)}
                 placeholder="Enter project name"
                 className={errors.name ? 'border-destructive' : ''}
+                aria-required="true"
+                aria-invalid={!!errors.name}
+                aria-describedby={errors.name ? 'name-error' : undefined}
               />
-              {errors.name && <p className="text-sm text-destructive">{errors.name}</p>}
+              {errors.name && <p id="name-error" className="text-sm text-destructive" role="alert">{errors.name}</p>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="project_type_id">Project Type *</Label>
+              <Label htmlFor="project_type_id">Project Type <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Select value={formData.project_type_id} onValueChange={(value) => handleChange('project_type_id', value)}>
-                <SelectTrigger className={errors.project_type_id ? 'border-destructive' : ''}>
+                <SelectTrigger
+                  id="project_type_id"
+                  className={errors.project_type_id ? 'border-destructive' : ''}
+                  aria-required="true"
+                  aria-invalid={!!errors.project_type_id}
+                  aria-describedby={errors.project_type_id ? 'project_type_id-error' : undefined}
+                >
                   <SelectValue placeholder="Select project type" />
                 </SelectTrigger>
                 <SelectContent>
@@ -292,13 +302,19 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
                   ))}
                 </SelectContent>
               </Select>
-              {errors.project_type_id && <p className="text-sm text-destructive">{errors.project_type_id}</p>}
+              {errors.project_type_id && <p id="project_type_id-error" className="text-sm text-destructive" role="alert">{errors.project_type_id}</p>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="location_id">Location *</Label>
+              <Label htmlFor="location_id">Location <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Select value={formData.location_id} onValueChange={(value) => handleChange('location_id', value)}>
-                <SelectTrigger className={errors.location_id ? 'border-destructive' : ''}>
+                <SelectTrigger
+                  id="location_id"
+                  className={errors.location_id ? 'border-destructive' : ''}
+                  aria-required="true"
+                  aria-invalid={!!errors.location_id}
+                  aria-describedby={errors.location_id ? 'location_id-error' : undefined}
+                >
                   <SelectValue placeholder="Select location" />
                 </SelectTrigger>
                 <SelectContent>
@@ -309,13 +325,19 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
                   ))}
                 </SelectContent>
               </Select>
-              {errors.location_id && <p className="text-sm text-destructive">{errors.location_id}</p>}
+              {errors.location_id && <p id="location_id-error" className="text-sm text-destructive" role="alert">{errors.location_id}</p>}
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="owner_id">Project Owner *</Label>
+              <Label htmlFor="owner_id">Project Owner <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Select value={formData.owner_id} onValueChange={(value) => handleChange('owner_id', value)}>
-                <SelectTrigger className={errors.owner_id ? 'border-destructive' : ''}>
+                <SelectTrigger
+                  id="owner_id"
+                  className={errors.owner_id ? 'border-destructive' : ''}
+                  aria-required="true"
+                  aria-invalid={!!errors.owner_id}
+                  aria-describedby={errors.owner_id ? 'owner_id-error' : undefined}
+                >
                   <SelectValue placeholder="Select project owner" />
                 </SelectTrigger>
                 <SelectContent>
@@ -326,13 +348,13 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
                   ))}
                 </SelectContent>
               </Select>
-              {errors.owner_id && <p className="text-sm text-destructive">{errors.owner_id}</p>}
+              {errors.owner_id && <p id="owner_id-error" className="text-sm text-destructive" role="alert">{errors.owner_id}</p>}
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="priority">Priority</Label>
               <Select value={formData.priority.toString()} onValueChange={(value) => handleChange('priority', Number(value))}>
-                <SelectTrigger>
+                <SelectTrigger id="priority">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -358,7 +380,7 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
             <div className="space-y-2 col-span-2">
               <Label htmlFor="current_phase_id">Current Phase</Label>
               <Select value={formData.current_phase_id || 'none'} onValueChange={(value) => handleChange('current_phase_id', value === 'none' ? '' : value)}>
-                <SelectTrigger>
+                <SelectTrigger id="current_phase_id">
                   <SelectValue placeholder="Select current phase" />
                 </SelectTrigger>
                 <SelectContent>
@@ -400,10 +422,12 @@ export const ProjectModal: React.FC<ProjectModalProps> = ({
               id="include_in_demand"
               checked={formData.include_in_demand}
               onCheckedChange={(checked) => handleChange('include_in_demand', checked)}
+              aria-describedby="include_in_demand-description"
             />
             <Label htmlFor="include_in_demand" className="cursor-pointer">
               Include in demand planning
             </Label>
+            <span id="include_in_demand-description" className="sr-only">Include this project in demand planning calculations</span>
           </div>
 
             <DialogFooter>

--- a/client/src/components/modals/ProjectTypeModal.tsx
+++ b/client/src/components/modals/ProjectTypeModal.tsx
@@ -14,6 +14,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../ui/dialog';
 
@@ -153,17 +154,17 @@ export const ProjectTypeModal: React.FC<ProjectTypeModalProps> = ({
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit Project Type' : 'Create Project Type'}</DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'Update the project type details below.'
+              : 'Fill in the information to create a new project type.'}
+          </DialogDescription>
         </DialogHeader>
         <div className="py-4">
-        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
-          {isEditing 
-            ? 'Update the project type details below.' 
-            : 'Fill in the information to create a new project type.'}
-        </p>
 
           {hasErrors && (
-            <Alert variant="destructive" className="mb-6">
-              <AlertCircle className="h-4 w-4" />
+            <Alert variant="destructive" className="mb-6" role="alert" aria-live="assertive">
+              <AlertCircle className="h-4 w-4" aria-hidden="true" />
               <AlertDescription>
                 Please fix the errors below before submitting.
               </AlertDescription>
@@ -172,7 +173,7 @@ export const ProjectTypeModal: React.FC<ProjectTypeModalProps> = ({
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-2">
-            <Label htmlFor="name">Name *</Label>
+            <Label htmlFor="name">Name <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
             <Input
               id="name"
               value={formData.name}
@@ -180,8 +181,11 @@ export const ProjectTypeModal: React.FC<ProjectTypeModalProps> = ({
               placeholder="Enter project type name"
               maxLength={100}
               className={errors.name ? 'border-destructive' : ''}
+              aria-required="true"
+              aria-invalid={!!errors.name}
+              aria-describedby={errors.name ? 'name-error' : undefined}
             />
-            {errors.name && <p className="text-sm text-destructive">{errors.name}</p>}
+            {errors.name && <p id="name-error" className="text-sm text-destructive" role="alert">{errors.name}</p>}
           </div>
 
           <div className="space-y-2">
@@ -209,20 +213,21 @@ export const ProjectTypeModal: React.FC<ProjectTypeModalProps> = ({
                 <span className="text-sm text-muted-foreground">{formData.color_code}</span>
               </div>
               
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap gap-2" role="group" aria-label="Color selection">
                 {DEFAULT_COLORS.map((color) => (
                   <button
                     key={color}
                     type="button"
                     className={cn(
                       "h-8 w-8 rounded-md border-2 transition-all",
-                      formData.color_code === color 
-                        ? "border-primary scale-110" 
+                      formData.color_code === color
+                        ? "border-primary scale-110"
                         : "border-transparent hover:scale-105"
                     )}
                     style={{ backgroundColor: color }}
                     onClick={() => handleChange('color_code', color)}
-                    title={`Select ${color}`}
+                    aria-label={`Select color ${color}`}
+                    aria-pressed={formData.color_code === color}
                   />
                 ))}
               </div>

--- a/client/src/components/modals/ScenarioMergeModal.tsx
+++ b/client/src/components/modals/ScenarioMergeModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from '../ui/dialog';
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
@@ -160,8 +161,8 @@ export const ScenarioMergeModal: React.FC<ScenarioMergeModalProps> = ({
       </div>
 
       <div className="space-y-3">
-        <Label className="text-base font-semibold">Merge Strategy</Label>
-        <RadioGroup value={mergeStrategy} onValueChange={(value) => setMergeStrategy(value as any)}>
+        <Label className="text-base font-semibold" id="merge-strategy-label">Merge Strategy</Label>
+        <RadioGroup value={mergeStrategy} onValueChange={(value) => setMergeStrategy(value as any)} aria-labelledby="merge-strategy-label">
           <div className="space-y-3">
             <Label
               htmlFor="strategy-manual"
@@ -221,7 +222,7 @@ export const ScenarioMergeModal: React.FC<ScenarioMergeModalProps> = ({
       </div>
 
       {error && (
-        <div className="mt-4 p-3 bg-destructive/10 border border-destructive text-destructive rounded-md text-sm">
+        <div className="mt-4 p-3 bg-destructive/10 border border-destructive text-destructive rounded-md text-sm" role="alert" aria-live="assertive">
           {error}
         </div>
       )}
@@ -468,9 +469,12 @@ export const ScenarioMergeModal: React.FC<ScenarioMergeModalProps> = ({
       <DialogContent className="scenario-merge-modal max-w-4xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <GitMerge size={20} />
+            <GitMerge size={20} aria-hidden="true" />
             Scenario Merge
           </DialogTitle>
+          <DialogDescription>
+            Merge changes from this scenario back to its parent scenario.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="modal-body">

--- a/client/src/components/modals/ScenarioModal.tsx
+++ b/client/src/components/modals/ScenarioModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../ui/dialog';
 import { Button } from '../ui/button';
@@ -66,18 +67,21 @@ export const CreateScenarioModal: React.FC<CreateScenarioModalProps> = ({
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Create New Scenario</DialogTitle>
+          <DialogDescription>
+            Create a new scenario to plan and test different resource allocations.
+          </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-4">
             {parentScenario && (
-              <div className="flex items-center gap-2 p-3 bg-blue-50 dark:bg-blue-950 rounded-md">
-                <GitBranch size={16} />
+              <div className="flex items-center gap-2 p-3 bg-blue-50 dark:bg-blue-950 rounded-md" role="status">
+                <GitBranch size={16} aria-hidden="true" />
                 <span className="text-sm">Branching from: <strong>{parentScenario.name}</strong></span>
               </div>
             )}
 
             <div className="space-y-2">
-              <Label htmlFor="scenario-name">Scenario Name *</Label>
+              <Label htmlFor="scenario-name">Scenario Name <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Input
                 id="scenario-name"
                 type="text"
@@ -85,6 +89,7 @@ export const CreateScenarioModal: React.FC<CreateScenarioModalProps> = ({
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Enter scenario name"
                 required
+                aria-required="true"
               />
             </div>
 
@@ -176,11 +181,14 @@ export const EditScenarioModal: React.FC<EditScenarioModalProps> = ({
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Edit Scenario</DialogTitle>
+          <DialogDescription>
+            Update the scenario details below.
+          </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-4">
             <div className="space-y-2">
-              <Label htmlFor="edit-scenario-name">Scenario Name *</Label>
+              <Label htmlFor="edit-scenario-name">Scenario Name <span aria-hidden="true">*</span><span className="sr-only">(required)</span></Label>
               <Input
                 id="edit-scenario-name"
                 type="text"
@@ -188,6 +196,7 @@ export const EditScenarioModal: React.FC<EditScenarioModalProps> = ({
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Enter scenario name"
                 required
+                aria-required="true"
               />
             </div>
 
@@ -253,9 +262,12 @@ export const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = (
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Delete Scenario</DialogTitle>
+          <DialogDescription>
+            Permanently delete this scenario and all associated data.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-4 py-4">
-          <div className="p-4 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-md">
+          <div className="p-4 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-md" role="alert">
             <p className="text-sm text-red-800 dark:text-red-200">
               <strong>Warning:</strong> This action cannot be undone. This will permanently delete
               the scenario <strong>{scenario?.name}</strong> and all associated data.
@@ -264,7 +276,7 @@ export const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = (
 
           <div className="space-y-2">
             <Label htmlFor="confirm-delete">
-              Type <strong>{scenario?.name}</strong> to confirm deletion
+              Type <strong>{scenario?.name}</strong> to confirm deletion <span aria-hidden="true">*</span><span className="sr-only">(required)</span>
             </Label>
             <Input
               id="confirm-delete"
@@ -272,7 +284,10 @@ export const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = (
               value={confirmText}
               onChange={(e) => setConfirmText(e.target.value)}
               placeholder="Enter scenario name"
+              aria-required="true"
+              aria-describedby="delete-warning"
             />
+            <span id="delete-warning" className="sr-only">You must type the scenario name exactly to enable the delete button</span>
           </div>
         </div>
 

--- a/client/src/components/modals/SmartAssignmentModal.tsx
+++ b/client/src/components/modals/SmartAssignmentModal.tsx
@@ -810,7 +810,7 @@ export function SmartAssignmentModal({
                 <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="project-select">
-                    Project *
+                    Project <span aria-hidden="true">*</span><span className="sr-only">(required)</span>
                     {!isLoadingAllocations && projectsWithDemand.length > 0 && projectsWithDemand.length < (projects?.data?.length || 0) && (
                       <span className="text-xs text-muted-foreground font-normal ml-2">
                         ({projectsWithDemand.length} with resource needs)
@@ -822,7 +822,7 @@ export function SmartAssignmentModal({
                     onValueChange={(value) => handleFormChange('project_id', value)}
                     disabled={!isLoadingAllocations && projectsWithDemand.length === 0}
                   >
-                    <SelectTrigger id="project-select">
+                    <SelectTrigger id="project-select" aria-required="true">
                       <SelectValue placeholder={
                         isLoadingAllocations
                           ? 'Loading projects...'
@@ -843,7 +843,7 @@ export function SmartAssignmentModal({
 
                 <div className="space-y-2">
                   <Label htmlFor="role-select">
-                    Role *
+                    Role <span aria-hidden="true">*</span><span className="sr-only">(required)</span>
                     {formData.project_id && projectRoles.length > 0 && (
                       <span className="text-xs text-muted-foreground font-normal ml-2">
                         ({projectRoles.length} roles needed)
@@ -855,7 +855,7 @@ export function SmartAssignmentModal({
                     onValueChange={(value) => handleFormChange('role_id', value)}
                     disabled={!formData.project_id || projectRoles.length === 0 || projectsWithDemand.length === 0}
                   >
-                    <SelectTrigger id="role-select">
+                    <SelectTrigger id="role-select" aria-required="true">
                       <SelectValue placeholder={
                         formData.project_id && projectRoles.length === 0
                           ? 'No roles needed for this project'
@@ -969,7 +969,7 @@ export function SmartAssignmentModal({
 
                 <div className="space-y-2">
                   <Label htmlFor="start-date">
-                    Start Date *
+                    Start Date <span aria-hidden="true">*</span><span className="sr-only">(required)</span>
                     {formData.phase_id && (
                       <span className="text-xs text-primary font-normal ml-2">
                         (Linked to phase)
@@ -982,6 +982,7 @@ export function SmartAssignmentModal({
                     value={formData.start_date}
                     onChange={(e) => handleFormChange('start_date', e.target.value)}
                     required
+                    aria-required="true"
                     disabled={!!formData.phase_id}
                     className={formData.phase_id ? 'opacity-70 cursor-not-allowed' : ''}
                   />
@@ -989,7 +990,7 @@ export function SmartAssignmentModal({
 
                 <div className="space-y-2">
                   <Label htmlFor="end-date">
-                    End Date *
+                    End Date <span aria-hidden="true">*</span><span className="sr-only">(required)</span>
                     {formData.phase_id && (
                       <span className="text-xs text-primary font-normal ml-2">
                         (Linked to phase)
@@ -1003,6 +1004,7 @@ export function SmartAssignmentModal({
                     onChange={(e) => handleFormChange('end_date', e.target.value)}
                     min={formData.start_date}
                     required
+                    aria-required="true"
                     disabled={!!formData.phase_id}
                     className={formData.phase_id ? 'opacity-70 cursor-not-allowed' : ''}
                   />
@@ -1017,12 +1019,12 @@ export function SmartAssignmentModal({
             <div className={cn(
               "impact-preview",
               impactPreview.isOverallocated ? "warning" : "success"
-            )}>
+            )} role="status" aria-live="polite">
               <div className="impact-header">
                 {impactPreview.isOverallocated ? (
-                  <AlertTriangle size={20} />
+                  <AlertTriangle size={20} aria-hidden="true" />
                 ) : (
-                  <CheckCircle size={20} />
+                  <CheckCircle size={20} aria-hidden="true" />
                 )}
                 <h4>Assignment Impact</h4>
               </div>

--- a/client/src/components/modals/TestModal.tsx
+++ b/client/src/components/modals/TestModal.tsx
@@ -4,6 +4,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from '../ui/dialog';
 import { Button } from '../ui/button';
@@ -26,6 +27,9 @@ export const TestModal: React.FC<TestModalProps> = ({ isOpen, onClose }) => {
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>Test Modal - Dialog Version</DialogTitle>
+          <DialogDescription>
+            A test modal to verify the dialog system is working correctly.
+          </DialogDescription>
         </DialogHeader>
         <div className="py-4">
           <h2 className="text-lg font-bold mb-2">

--- a/client/src/components/modals/__tests__/AssignmentModalNew.test.tsx
+++ b/client/src/components/modals/__tests__/AssignmentModalNew.test.tsx
@@ -88,8 +88,8 @@ describe('AssignmentModalNew', () => {
     // Default mock responses
     (api.projects.list as jest.Mock).mockResolvedValue(mockProjects);
     (api.people.list as jest.Mock).mockResolvedValue(mockPeople);
-    (api.roles.list as jest.Mock).mockResolvedValue({ data: mockRoles });
-    (api.phases.list as jest.Mock).mockResolvedValue({ data: mockPhases });
+    (api.roles.list as jest.Mock).mockResolvedValue({ data: { data: mockRoles } });
+    (api.phases.list as jest.Mock).mockResolvedValue({ data: { data: mockPhases } });
     (api.projects.get as jest.Mock).mockResolvedValue({ data: { phases: mockProjectPhases } });
 
     // Mock scrollIntoView for Radix Select
@@ -140,9 +140,9 @@ describe('AssignmentModalNew', () => {
     it('renders all form fields', async () => {
       renderComponent();
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Person \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Role \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /person/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
         expect(screen.getByLabelText(/Start Date \*/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/End Date \*/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/Allocation % \*/i)).toBeInTheDocument();
@@ -217,6 +217,39 @@ describe('AssignmentModalNew', () => {
       renderComponent();
       await waitFor(() => {
         expect(api.phases.list).toHaveBeenCalled();
+      });
+    });
+
+    it('handles roles API returning undefined data gracefully', async () => {
+      (api.roles.list as jest.Mock).mockResolvedValue({ data: undefined });
+
+      renderComponent();
+
+      // Should not crash, component should render
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Create New Assignment/i })).toBeInTheDocument();
+      });
+    });
+
+    it('handles roles API returning non-array data gracefully', async () => {
+      (api.roles.list as jest.Mock).mockResolvedValue({ data: { data: null } });
+
+      renderComponent();
+
+      // Should not crash, component should render
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Create New Assignment/i })).toBeInTheDocument();
+      });
+    });
+
+    it('handles malformed roles API response gracefully', async () => {
+      (api.roles.list as jest.Mock).mockResolvedValue({ data: { wrongKey: [] } });
+
+      renderComponent();
+
+      // Should not crash when roles is undefined
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Create New Assignment/i })).toBeInTheDocument();
       });
     });
   });
@@ -474,9 +507,9 @@ describe('AssignmentModalNew', () => {
     it('has proper labels for form fields', async () => {
       renderComponent();
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Person \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Role \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /person/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
         expect(screen.getByLabelText(/Start Date \*/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/End Date \*/i)).toBeInTheDocument();
       });

--- a/client/src/components/modals/__tests__/LocationModal.test.tsx
+++ b/client/src/components/modals/__tests__/LocationModal.test.tsx
@@ -302,7 +302,9 @@ describe('LocationModal', () => {
         new Error('API Error')
       );
 
-      renderComponent();
+      // Recreate component with fresh mock to avoid race conditions
+      const freshOnSave = jest.fn();
+      render(<LocationModal onSave={freshOnSave} onCancel={mockOnCancel} />);
 
       fireEvent.change(screen.getByLabelText(/Name/i), {
         target: { value: 'Test' }
@@ -314,7 +316,10 @@ describe('LocationModal', () => {
         expect(screen.getByText('Failed to save location')).toBeInTheDocument();
       });
 
-      expect(mockOnSave).not.toHaveBeenCalled();
+      // Wait a bit to ensure all async operations complete
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(freshOnSave).not.toHaveBeenCalled();
     });
   });
 
@@ -344,13 +349,14 @@ describe('LocationModal', () => {
   describe('Accessibility', () => {
     it('has proper labels for form fields', () => {
       renderComponent();
-      expect(screen.getByLabelText(/Name \*/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Name/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
     });
 
     it('shows asterisk for required field', () => {
       renderComponent();
-      expect(screen.getByText(/Name \*/i)).toBeInTheDocument();
+      // The asterisk is now hidden from screen readers with aria-hidden
+      expect(screen.getByText('*')).toBeInTheDocument();
     });
 
     it('has proper dialog structure', () => {

--- a/client/src/components/modals/__tests__/PersonRoleModal.test.tsx
+++ b/client/src/components/modals/__tests__/PersonRoleModal.test.tsx
@@ -125,11 +125,11 @@ describe('PersonRoleModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Role *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
       });
 
       // Proficiency should default to level 3 - verify through the label
-      expect(screen.getByText('Proficiency Level *')).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /proficiency/i })).toBeInTheDocument();
 
       // Primary role checkbox should be unchecked
       const primaryCheckbox = screen.getByRole('checkbox', { name: /Set as Primary Role/i });
@@ -200,7 +200,7 @@ describe('PersonRoleModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Role *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
       });
     });
 
@@ -212,7 +212,7 @@ describe('PersonRoleModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Role *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
       });
     });
 
@@ -224,7 +224,7 @@ describe('PersonRoleModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Role *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
       });
     });
 
@@ -243,7 +243,7 @@ describe('PersonRoleModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Proficiency Level *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /proficiency/i })).toBeInTheDocument();
       });
     });
 
@@ -251,18 +251,18 @@ describe('PersonRoleModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Proficiency Level *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /proficiency/i })).toBeInTheDocument();
       });
 
       // Verify the proficiency level field is present and has default behavior
-      expect(screen.getByText('Proficiency Level *')).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /proficiency/i })).toBeInTheDocument();
     });
 
     it('allows changing proficiency level in add mode', async () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Proficiency Level *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /proficiency/i })).toBeInTheDocument();
       });
     });
 
@@ -277,7 +277,7 @@ describe('PersonRoleModal', () => {
       renderComponent({ editingRole });
 
       await waitFor(() => {
-        expect(screen.getByText('Proficiency Level *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /proficiency/i })).toBeInTheDocument();
       });
     });
   });
@@ -537,8 +537,8 @@ describe('PersonRoleModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Role *')).toBeInTheDocument();
-        expect(screen.getByText('Proficiency Level *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /proficiency/i })).toBeInTheDocument();
         expect(screen.getByText('Start Date')).toBeInTheDocument();
         expect(screen.getByText('End Date')).toBeInTheDocument();
       });
@@ -556,8 +556,8 @@ describe('PersonRoleModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        expect(screen.getByText('Role *')).toBeInTheDocument();
-        expect(screen.getByText('Proficiency Level *')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /proficiency/i })).toBeInTheDocument();
       });
     });
   });

--- a/client/src/components/modals/__tests__/ProjectModal.test.tsx
+++ b/client/src/components/modals/__tests__/ProjectModal.test.tsx
@@ -138,10 +138,10 @@ describe('ProjectModal', () => {
     it('renders form fields', async () => {
       renderComponent();
       await waitFor(() => {
-        expect(screen.getByLabelText(/Project Name \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Project Type \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Location \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Project Owner \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /project name/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project type/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /location/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project owner/i })).toBeInTheDocument();
       });
     });
   });
@@ -150,7 +150,7 @@ describe('ProjectModal', () => {
     it('initializes with empty values for new project', async () => {
       renderComponent();
       await waitFor(() => {
-        const nameInput = screen.getByLabelText(/Project Name \*/i) as HTMLInputElement;
+        const nameInput = screen.getByRole('textbox', { name: /project name/i }) as HTMLInputElement;
         expect(nameInput.value).toBe('');
       });
     });
@@ -159,7 +159,7 @@ describe('ProjectModal', () => {
       renderComponent();
       await waitFor(() => {
         // Priority select exists and has a default value
-        const nameInput = screen.getByLabelText(/Project Name \*/i);
+        const nameInput = screen.getByRole('textbox', { name: /project name/i });
         expect(nameInput).toBeInTheDocument();
       });
     });
@@ -175,7 +175,7 @@ describe('ProjectModal', () => {
     it('populates form with project data when editing', async () => {
       renderComponent({ editingProject: mockProject });
       await waitFor(() => {
-        const nameInput = screen.getByLabelText(/Project Name \*/i) as HTMLInputElement;
+        const nameInput = screen.getByRole('textbox', { name: /project name/i }) as HTMLInputElement;
         const descriptionInput = screen.getByLabelText(/Description/i) as HTMLTextAreaElement;
         const externalIdInput = screen.getByLabelText(/External ID/i) as HTMLInputElement;
 
@@ -220,7 +220,7 @@ describe('ProjectModal', () => {
     it('allows typing in name field', async () => {
       renderComponent();
       await waitFor(() => {
-        const nameInput = screen.getByLabelText(/Project Name \*/i);
+        const nameInput = screen.getByRole('textbox', { name: /project name/i });
         fireEvent.change(nameInput, { target: { value: 'New Project' } });
         expect(nameInput).toHaveValue('New Project');
       });
@@ -320,7 +320,7 @@ describe('ProjectModal', () => {
         expect(screen.getByText('Project name is required')).toBeInTheDocument();
       });
 
-      const nameInput = screen.getByLabelText(/Project Name \*/i);
+      const nameInput = screen.getByRole('textbox', { name: /project name/i });
       fireEvent.change(nameInput, { target: { value: 'New Project' } });
 
       expect(screen.queryByText('Project name is required')).not.toBeInTheDocument();
@@ -375,7 +375,7 @@ describe('ProjectModal', () => {
       renderComponent({ editingProject: mockProject });
 
       await waitFor(() => {
-        const nameInput = screen.getByLabelText(/Project Name \*/i);
+        const nameInput = screen.getByRole('textbox', { name: /project name/i });
         fireEvent.change(nameInput, { target: { value: 'Updated Project' } });
       });
 
@@ -455,7 +455,7 @@ describe('ProjectModal', () => {
       renderComponent();
 
       await waitFor(() => {
-        const nameInput = screen.getByLabelText(/Project Name \*/i);
+        const nameInput = screen.getByRole('textbox', { name: /project name/i });
         fireEvent.change(nameInput, { target: { value: 'Test' } });
       });
 
@@ -470,7 +470,7 @@ describe('ProjectModal', () => {
     it('has proper labels for form fields', async () => {
       renderComponent();
       await waitFor(() => {
-        expect(screen.getByLabelText(/Project Name \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /project name/i })).toBeInTheDocument();
         expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/External ID/i)).toBeInTheDocument();
       });

--- a/client/src/components/modals/__tests__/ProjectTypeModal.test.tsx
+++ b/client/src/components/modals/__tests__/ProjectTypeModal.test.tsx
@@ -75,9 +75,9 @@ describe('ProjectTypeModal', () => {
 
     it('renders form fields', () => {
       renderComponent();
-      expect(screen.getByLabelText(/Name \*/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/Color/i)).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /name/i })).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /description/i })).toBeInTheDocument();
+      expect(screen.getByLabelText('Color')).toBeInTheDocument();
     });
 
     it('shows descriptive text for create mode', () => {
@@ -94,8 +94,8 @@ describe('ProjectTypeModal', () => {
   describe('Form Initialization', () => {
     it('initializes with empty values for new project type', () => {
       renderComponent();
-      const nameInput = screen.getByLabelText(/Name \*/i) as HTMLInputElement;
-      const descriptionInput = screen.getByLabelText(/Description/i) as HTMLTextAreaElement;
+      const nameInput = screen.getByRole('textbox', { name: /name/i }) as HTMLInputElement;
+      const descriptionInput = screen.getByRole('textbox', { name: /description/i }) as HTMLTextAreaElement;
 
       expect(nameInput.value).toBe('');
       expect(descriptionInput.value).toBe('');
@@ -103,15 +103,15 @@ describe('ProjectTypeModal', () => {
 
     it('initializes with default color', () => {
       renderComponent();
-      const colorInput = screen.getByLabelText(/Color/i) as HTMLInputElement;
+      const colorInput = screen.getByLabelText('Color') as HTMLInputElement;
       expect(colorInput.value).toBe('#4f46e5'); // Default indigo color
     });
 
     it('populates form with project type data when editing', () => {
       renderComponent({ editingProjectType: mockProjectType });
-      const nameInput = screen.getByLabelText(/Name \*/i) as HTMLInputElement;
-      const descriptionInput = screen.getByLabelText(/Description/i) as HTMLTextAreaElement;
-      const colorInput = screen.getByLabelText(/Color/i) as HTMLInputElement;
+      const nameInput = screen.getByRole('textbox', { name: /name/i }) as HTMLInputElement;
+      const descriptionInput = screen.getByRole('textbox', { name: /description/i }) as HTMLTextAreaElement;
+      const colorInput = screen.getByLabelText('Color') as HTMLInputElement;
 
       expect(nameInput.value).toBe('Product Development');
       expect(descriptionInput.value).toBe('Software product development projects');
@@ -130,7 +130,7 @@ describe('ProjectTypeModal', () => {
   describe('Form Interactions', () => {
     it('allows typing in name field', () => {
       renderComponent();
-      const nameInput = screen.getByLabelText(/Name \*/i);
+      const nameInput = screen.getByRole('textbox', { name: /name/i });
 
       fireEvent.change(nameInput, { target: { value: 'Consulting' } });
       expect(nameInput).toHaveValue('Consulting');
@@ -146,7 +146,7 @@ describe('ProjectTypeModal', () => {
 
     it('allows selecting color from color input', () => {
       renderComponent();
-      const colorInput = screen.getByLabelText(/Color/i);
+      const colorInput = screen.getByLabelText('Color');
 
       fireEvent.change(colorInput, { target: { value: '#10b981' } });
       expect(colorInput).toHaveValue('#10b981');
@@ -154,7 +154,7 @@ describe('ProjectTypeModal', () => {
 
     it('displays selected color code as text', () => {
       renderComponent();
-      const colorInput = screen.getByLabelText(/Color/i);
+      const colorInput = screen.getByLabelText('Color');
 
       fireEvent.change(colorInput, { target: { value: '#ef4444' } });
       expect(screen.getByText('#ef4444')).toBeInTheDocument();
@@ -162,7 +162,7 @@ describe('ProjectTypeModal', () => {
 
     it('enforces 100 character limit on name', () => {
       renderComponent();
-      const nameInput = screen.getByLabelText(/Name \*/i) as HTMLInputElement;
+      const nameInput = screen.getByRole('textbox', { name: /name/i }) as HTMLInputElement;
 
       expect(nameInput.maxLength).toBe(100);
     });
@@ -172,7 +172,7 @@ describe('ProjectTypeModal', () => {
     it('renders all preset color buttons', () => {
       renderComponent();
       const colorButtons = screen.getAllByRole('button').filter(
-        btn => btn.getAttribute('title')?.includes('Select #')
+        btn => btn.getAttribute('aria-label')?.includes('Select color #')
       );
       expect(colorButtons.length).toBe(10); // DEFAULT_COLORS has 10 colors
     });
@@ -180,7 +180,7 @@ describe('ProjectTypeModal', () => {
     it('highlights selected preset color', () => {
       renderComponent();
       const firstColorButton = screen.getAllByRole('button').find(
-        btn => btn.getAttribute('title') === 'Select #4f46e5'
+        btn => btn.getAttribute('aria-label') === 'Select color #4f46e5'
       );
       expect(firstColorButton).toHaveClass('border-primary');
     });
@@ -188,7 +188,7 @@ describe('ProjectTypeModal', () => {
     it('changes color when preset button is clicked', () => {
       renderComponent();
       const emeraldButton = screen.getAllByRole('button').find(
-        btn => btn.getAttribute('title') === 'Select #10b981'
+        btn => btn.getAttribute('aria-label') === 'Select color #10b981'
       );
 
       fireEvent.click(emeraldButton!);
@@ -197,9 +197,9 @@ describe('ProjectTypeModal', () => {
 
     it('updates color input when preset button is clicked', () => {
       renderComponent();
-      const colorInput = screen.getByLabelText(/Color/i) as HTMLInputElement;
+      const colorInput = screen.getByLabelText('Color') as HTMLInputElement;
       const amberButton = screen.getAllByRole('button').find(
-        btn => btn.getAttribute('title') === 'Select #f59e0b'
+        btn => btn.getAttribute('aria-label') === 'Select color #f59e0b'
       );
 
       fireEvent.click(amberButton!);
@@ -221,7 +221,7 @@ describe('ProjectTypeModal', () => {
 
     it('shows error when submitting with whitespace-only name', async () => {
       renderComponent();
-      const nameInput = screen.getByLabelText(/Name \*/i);
+      const nameInput = screen.getByRole('textbox', { name: /name/i });
       const submitButton = screen.getByRole('button', { name: /Create Project Type/i });
 
       fireEvent.change(nameInput, { target: { value: '   ' } });
@@ -245,7 +245,7 @@ describe('ProjectTypeModal', () => {
 
     it('clears errors when user starts typing', async () => {
       renderComponent();
-      const nameInput = screen.getByLabelText(/Name \*/i);
+      const nameInput = screen.getByRole('textbox', { name: /name/i });
       const submitButton = screen.getByRole('button', { name: /Create Project Type/i });
 
       // Trigger validation error
@@ -279,7 +279,7 @@ describe('ProjectTypeModal', () => {
       (api.projectTypes.create as jest.Mock).mockResolvedValue({ data: {} });
 
       renderComponent();
-      const nameInput = screen.getByLabelText(/Name \*/i);
+      const nameInput = screen.getByRole('textbox', { name: /name/i });
       const submitButton = screen.getByRole('button', { name: /Create Project Type/i });
 
       fireEvent.change(nameInput, { target: { value: 'Consulting' } });
@@ -301,13 +301,13 @@ describe('ProjectTypeModal', () => {
 
       renderComponent();
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'Research & Development' }
       });
       fireEvent.change(screen.getByLabelText(/Description/i), {
         target: { value: 'R&D projects' }
       });
-      fireEvent.change(screen.getByLabelText(/Color/i), {
+      fireEvent.change(screen.getByLabelText('Color'), {
         target: { value: '#8b5cf6' }
       });
 
@@ -329,7 +329,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent();
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'New Type' }
       });
 
@@ -345,7 +345,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent();
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'New Type' }
       });
 
@@ -363,7 +363,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent();
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'Test Type' }
       });
 
@@ -382,7 +382,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent();
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'Test Type' }
       });
 
@@ -401,7 +401,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent();
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'New Type' }
       });
 
@@ -422,7 +422,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent({ editingProjectType: mockProjectType });
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'Updated Name' }
       });
 
@@ -444,7 +444,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent({ editingProjectType: mockProjectType });
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'Updated' }
       });
 
@@ -460,7 +460,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent({ editingProjectType: mockProjectType });
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'Updated' }
       });
 
@@ -477,7 +477,7 @@ describe('ProjectTypeModal', () => {
 
       renderComponent({ editingProjectType: mockProjectType });
 
-      fireEvent.change(screen.getByLabelText(/Name \*/i), {
+      fireEvent.change(screen.getByRole('textbox', { name: /name/i }), {
         target: { value: 'Updated' }
       });
 
@@ -528,7 +528,7 @@ describe('ProjectTypeModal', () => {
       );
 
       // Verify it's populated
-      expect(screen.getByLabelText(/Name \*/i)).toHaveValue('Product Development');
+      expect(screen.getByRole('textbox', { name: /name/i })).toHaveValue('Product Development');
 
       // Switch to create mode
       rerender(
@@ -538,7 +538,7 @@ describe('ProjectTypeModal', () => {
       );
 
       // Verify form is cleared
-      expect(screen.getByLabelText(/Name \*/i)).toHaveValue('');
+      expect(screen.getByRole('textbox', { name: /name/i })).toHaveValue('');
     });
 
     it('clears errors when switching between modes', async () => {
@@ -570,14 +570,15 @@ describe('ProjectTypeModal', () => {
   describe('Accessibility', () => {
     it('has proper labels for form fields', () => {
       renderComponent();
-      expect(screen.getByLabelText(/Name \*/i)).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /name/i })).toBeInTheDocument();
       expect(screen.getByLabelText(/Description/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/Color/i)).toBeInTheDocument();
+      expect(screen.getByLabelText('Color')).toBeInTheDocument();
     });
 
     it('shows asterisk for required field', () => {
       renderComponent();
-      expect(screen.getByText(/Name \*/i)).toBeInTheDocument();
+      // The asterisk is now hidden from screen readers with aria-hidden
+      expect(screen.getByText('*')).toBeInTheDocument();
     });
 
     it('has proper dialog structure', () => {
@@ -585,16 +586,36 @@ describe('ProjectTypeModal', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
-    it('color preset buttons have descriptive titles', () => {
+    it('color preset buttons have descriptive aria-labels', () => {
       renderComponent();
       const colorButtons = screen.getAllByRole('button').filter(
-        btn => btn.getAttribute('title')?.includes('Select #')
+        btn => btn.getAttribute('aria-label')?.includes('Select color #')
       );
 
       colorButtons.forEach(button => {
-        expect(button).toHaveAttribute('title');
-        expect(button.getAttribute('title')).toMatch(/Select #[0-9a-f]{6}/i);
+        expect(button).toHaveAttribute('aria-label');
+        expect(button.getAttribute('aria-label')).toMatch(/Select color #[0-9a-f]{6}/i);
       });
+    });
+
+    it('has aria-required on required fields', () => {
+      renderComponent();
+      const nameInput = screen.getByRole('textbox', { name: /name/i });
+      expect(nameInput).toHaveAttribute('aria-required', 'true');
+    });
+
+    it('has color selection group with proper aria-label', () => {
+      renderComponent();
+      expect(screen.getByRole('group', { name: /Color selection/i })).toBeInTheDocument();
+    });
+
+    it('has aria-pressed state on color buttons', () => {
+      renderComponent();
+      const selectedButton = screen.getByRole('button', { name: /Select color #4f46e5/i });
+      expect(selectedButton).toHaveAttribute('aria-pressed', 'true');
+
+      const unselectedButton = screen.getByRole('button', { name: /Select color #10b981/i });
+      expect(unselectedButton).toHaveAttribute('aria-pressed', 'false');
     });
   });
 });

--- a/client/src/components/modals/__tests__/SmartAssignmentModal.test.tsx
+++ b/client/src/components/modals/__tests__/SmartAssignmentModal.test.tsx
@@ -235,7 +235,8 @@ describe('SmartAssignmentModal', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        // Look for the label text (ARIA-enhanced structure now has asterisk in separate span)
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
     });
 
@@ -250,7 +251,7 @@ describe('SmartAssignmentModal', () => {
     it('defaults to manual tab when triggerContext is manual_add', async () => {
       renderComponent({ triggerContext: 'manual_add' });
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
     });
   });
@@ -287,16 +288,16 @@ describe('SmartAssignmentModal', () => {
     beforeEach(async () => {
       renderComponent({ triggerContext: 'manual_add' });
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
     });
 
     it('renders all form fields', () => {
-      expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
-      expect(screen.getByText(/Role \*/i)).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
       expect(screen.getByText(/Phase/i)).toBeInTheDocument();
-      expect(screen.getByText(/Start Date \*/i)).toBeInTheDocument();
-      expect(screen.getByText(/End Date \*/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Start Date/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/End Date/i)).toBeInTheDocument();
     });
 
     it('renders allocation slider', () => {
@@ -314,7 +315,7 @@ describe('SmartAssignmentModal', () => {
     beforeEach(async () => {
       renderComponent({ triggerContext: 'manual_add' });
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
     });
 
@@ -381,7 +382,7 @@ describe('SmartAssignmentModal', () => {
     beforeEach(async () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
     });
 
@@ -402,7 +403,7 @@ describe('SmartAssignmentModal', () => {
     beforeEach(async () => {
       renderComponent({ triggerContext: 'manual_add' });
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
     });
 
@@ -419,7 +420,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       // Form is populated with project, now submit
@@ -459,7 +460,7 @@ describe('SmartAssignmentModal', () => {
     beforeEach(async () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
     });
 
@@ -506,10 +507,10 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Role \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/Start Date \*/i)).toBeInTheDocument();
-        expect(screen.getByText(/End Date \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
+        expect(screen.getByLabelText(/Start Date/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/End Date/i)).toBeInTheDocument();
       });
     });
 
@@ -804,7 +805,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       // Date inputs should exist
@@ -855,7 +856,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       // The form submission logic includes phase_id and date mode
@@ -888,7 +889,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       }, { timeout: 3000 });
 
       // Should show only Project Alpha and Project Gamma (with demand)
@@ -914,7 +915,7 @@ describe('SmartAssignmentModal', () => {
 
       // Wait for the manual tab to render
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       // Wait for projects to be fetched
@@ -923,7 +924,7 @@ describe('SmartAssignmentModal', () => {
       });
 
       // Component should render without error, showing project selection
-      expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
     });
 
     it('extracts required roles from project allocations', async () => {
@@ -946,7 +947,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       // Required roles should be extracted from allocations > 0
@@ -974,7 +975,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Role \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
       });
 
       // Only roles with demand should be shown in the dropdown
@@ -996,7 +997,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Role \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
       });
 
       // Primary role should be pre-selected (role-1 from mockPerson)
@@ -1017,7 +1018,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent(formWithInvalidRole);
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       // If role validation fails, alert should be shown
@@ -1030,7 +1031,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       const submitButton = screen.getByRole('button', { name: /Create Assignment/i });
@@ -1043,7 +1044,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       // The payload should include assignment_date_mode: 'fixed' or 'phase'
@@ -1066,7 +1067,7 @@ describe('SmartAssignmentModal', () => {
       renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
       await waitFor(() => {
-        expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
       });
 
       // Error handling is tested through the mutation onError callback
@@ -1168,7 +1169,7 @@ describe('SmartAssignmentModal', () => {
         renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
         await waitFor(() => {
-          expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+          expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
         });
 
         // Wait for project allocations to load and form to be ready
@@ -1221,7 +1222,7 @@ describe('SmartAssignmentModal', () => {
         renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
         await waitFor(() => {
-          expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+          expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
         });
 
         // Fill form and attempt submission
@@ -1247,7 +1248,7 @@ describe('SmartAssignmentModal', () => {
         renderComponent({ triggerContext: 'manual_add' });
 
         await waitFor(() => {
-          expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+          expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
         });
 
         // Submit button should be disabled when no project selected
@@ -1284,7 +1285,7 @@ describe('SmartAssignmentModal', () => {
         renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
         await waitFor(() => {
-          expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+          expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
         });
 
         // Wait for utilization data to load and check remaining capacity
@@ -1331,7 +1332,7 @@ describe('SmartAssignmentModal', () => {
         renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
         await waitFor(() => {
-          expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+          expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
         });
 
         // Should auto-adjust to not exceed 100%
@@ -1348,12 +1349,12 @@ describe('SmartAssignmentModal', () => {
         renderComponent({ triggerContext: 'manual_add', projectId: 'project-2' });
 
         await waitFor(() => {
-          expect(screen.getByText(/Project \*/i)).toBeInTheDocument();
+          expect(screen.getByRole('combobox', { name: /project/i })).toBeInTheDocument();
         });
 
         // Project is pre-selected, now the role field should be available
         await waitFor(() => {
-          expect(screen.getByText(/Role \*/i)).toBeInTheDocument();
+          expect(screen.getByRole('combobox', { name: /role/i })).toBeInTheDocument();
         });
 
         // Form should be in a valid state


### PR DESCRIPTION
## Summary
- Add ARIA accessibility attributes across all 10 modal components to improve screen reader support
- Add `DialogDescription` to all dialogs for proper context announcements
- Add `aria-required`, `aria-invalid`, and `aria-describedby` for form validation
- Add `role="alert"` and `aria-live="assertive"` for error announcements
- Convert visual-only asterisks to accessible `sr-only` text patterns
- Update all modal tests to use `getByRole` selectors that work with accessible names

## Test plan
- [x] All 413 modal component tests pass
- [x] All 1434 client tests pass
- [x] Verified ARIA attributes render correctly in components
- [x] Screen reader accessible names computed correctly from label + sr-only text

## Components Updated
- AssignmentModalNew
- PersonModal
- PersonRoleModal  
- ProjectModal
- LocationModal
- ScenarioModal (Create, Edit, Delete)
- ScenarioMergeModal
- ProjectTypeModal
- SmartAssignmentModal
- TestModal

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)