### PR TITLE
feat: extract reusable useModalForm hook from duplicate modal code (closes #44)

### DIFF
--- a/client/src/hooks/__tests__/useModalForm.test.tsx
+++ b/client/src/hooks/__tests__/useModalForm.test.tsx
@@ -1,0 +1,374 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useModalForm, UseModalFormConfig } from '../useModalForm';
+
+// Create a wrapper with QueryClientProvider
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+interface TestFormData {
+  name: string;
+  email: string;
+  age: number;
+}
+
+describe('useModalForm', () => {
+  const defaultInitialValues: TestFormData = {
+    name: '',
+    email: '',
+    age: 0,
+  };
+
+  const createMockConfig = (
+    overrides: Partial<UseModalFormConfig<TestFormData>> = {}
+  ): UseModalFormConfig<TestFormData> => ({
+    initialValues: defaultInitialValues,
+    onCreate: jest.fn().mockResolvedValue({ id: '1', ...defaultInitialValues }),
+    onUpdate: jest.fn().mockResolvedValue({ id: '1', ...defaultInitialValues }),
+    queryKeysToInvalidate: [['users']],
+    onClose: jest.fn(),
+    ...overrides,
+  });
+
+  describe('initialization', () => {
+    it('should initialize with initial values', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.values).toEqual(defaultInitialValues);
+      expect(result.current.errors).toEqual({});
+      expect(result.current.isEditing).toBe(false);
+      expect(result.current.isSubmitting).toBe(false);
+      expect(result.current.hasErrors).toBe(false);
+    });
+
+    it('should initialize with editing item values', () => {
+      const editingItem = { id: '1', name: 'John', email: 'john@example.com', age: 30 };
+      const config = createMockConfig({ editingItem });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.values.name).toBe('John');
+      expect(result.current.values.email).toBe('john@example.com');
+      expect(result.current.values.age).toBe(30);
+      expect(result.current.isEditing).toBe(true);
+    });
+
+    it('should use custom getValuesFromItem when provided', () => {
+      const editingItem = { id: '1', full_name: 'John Doe', contact_email: 'john@example.com' };
+      const getValuesFromItem = (item: any): TestFormData => ({
+        name: item.full_name,
+        email: item.contact_email,
+        age: 0,
+      });
+      const config = createMockConfig({ editingItem, getValuesFromItem });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.values.name).toBe('John Doe');
+      expect(result.current.values.email).toBe('john@example.com');
+    });
+  });
+
+  describe('handleChange', () => {
+    it('should update a single field value', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleChange('name', 'Jane');
+      });
+
+      expect(result.current.values.name).toBe('Jane');
+    });
+
+    it('should clear error for field when value changes', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      // Set an error manually
+      act(() => {
+        result.current.setErrors({ name: 'Name is required' });
+      });
+      expect(result.current.errors.name).toBe('Name is required');
+
+      // Change the field value
+      act(() => {
+        result.current.handleChange('name', 'Jane');
+      });
+
+      expect(result.current.errors.name).toBe('');
+    });
+  });
+
+  describe('validation', () => {
+    it('should run validation on submit', async () => {
+      const validate = jest.fn().mockReturnValue({ name: 'Name is required' });
+      const config = createMockConfig({ validate });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      const mockEvent = { preventDefault: jest.fn() } as unknown as React.FormEvent;
+      act(() => {
+        result.current.handleSubmit(mockEvent);
+      });
+
+      expect(validate).toHaveBeenCalledWith(defaultInitialValues);
+      expect(result.current.errors.name).toBe('Name is required');
+      expect(result.current.hasErrors).toBe(true);
+      expect(config.onCreate).not.toHaveBeenCalled();
+    });
+
+    it('should not submit if validation fails', async () => {
+      const validate = () => ({ email: 'Invalid email' });
+      const config = createMockConfig({ validate });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      const mockEvent = { preventDefault: jest.fn() } as unknown as React.FormEvent;
+      act(() => {
+        result.current.handleSubmit(mockEvent);
+      });
+
+      expect(config.onCreate).not.toHaveBeenCalled();
+      expect(config.onUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should submit if validation passes', async () => {
+      const validate = () => ({}); // No errors
+      const config = createMockConfig({ validate });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleChange('name', 'Jane');
+        result.current.handleChange('email', 'jane@example.com');
+      });
+
+      const mockEvent = { preventDefault: jest.fn() } as unknown as React.FormEvent;
+      act(() => {
+        result.current.handleSubmit(mockEvent);
+      });
+
+      await waitFor(() => {
+        expect(config.onCreate).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('submission', () => {
+    it('should call onCreate for new items', async () => {
+      const onCreate = jest.fn().mockResolvedValue({ id: '1', name: 'Jane' });
+      const config = createMockConfig({ onCreate });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleChange('name', 'Jane');
+      });
+
+      const mockEvent = { preventDefault: jest.fn() } as unknown as React.FormEvent;
+      act(() => {
+        result.current.handleSubmit(mockEvent);
+      });
+
+      await waitFor(() => {
+        expect(onCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'Jane' }));
+      });
+    });
+
+    it('should call onUpdate for editing items', async () => {
+      const editingItem = { id: '1', name: 'John', email: '', age: 0 };
+      const onUpdate = jest.fn().mockResolvedValue({ id: '1', name: 'Jane' });
+      const config = createMockConfig({ editingItem, onUpdate });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleChange('name', 'Jane');
+      });
+
+      const mockEvent = { preventDefault: jest.fn() } as unknown as React.FormEvent;
+      act(() => {
+        result.current.handleSubmit(mockEvent);
+      });
+
+      await waitFor(() => {
+        expect(onUpdate).toHaveBeenCalledWith('1', expect.objectContaining({ name: 'Jane' }));
+      });
+    });
+
+    it('should call onSuccess callback after successful create', async () => {
+      const onSuccess = jest.fn();
+      const onCreate = jest.fn().mockResolvedValue({ id: '1', name: 'Jane' });
+      const config = createMockConfig({ onCreate, onSuccess });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      const mockEvent = { preventDefault: jest.fn() } as unknown as React.FormEvent;
+      act(() => {
+        result.current.handleSubmit(mockEvent);
+      });
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith({ id: '1', name: 'Jane' }, false);
+      });
+    });
+
+    it('should call onClose after successful submission', async () => {
+      const onClose = jest.fn();
+      const config = createMockConfig({ onClose });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      const mockEvent = { preventDefault: jest.fn() } as unknown as React.FormEvent;
+      act(() => {
+        result.current.handleSubmit(mockEvent);
+      });
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset form to initial values', () => {
+      const config = createMockConfig();
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleChange('name', 'Jane');
+        result.current.handleChange('email', 'jane@example.com');
+        result.current.setErrors({ name: 'Error' });
+      });
+
+      expect(result.current.values.name).toBe('Jane');
+      expect(result.current.errors.name).toBe('Error');
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.values).toEqual(defaultInitialValues);
+      expect(result.current.errors).toEqual({});
+    });
+  });
+
+  describe('handleClose', () => {
+    it('should call onClose after delay', () => {
+      jest.useFakeTimers();
+      const onClose = jest.fn();
+      const config = createMockConfig({ onClose });
+      const { result } = renderHook(() => useModalForm(config), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.handleClose();
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(onClose).toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+  });
+
+  describe('editingItem changes', () => {
+    it('should update values when editingItem changes', () => {
+      const config = createMockConfig();
+      const { result, rerender } = renderHook(
+        ({ editingItem }) => useModalForm({ ...config, editingItem }),
+        {
+          wrapper: createWrapper(),
+          initialProps: { editingItem: undefined as any },
+        }
+      );
+
+      expect(result.current.values).toEqual(defaultInitialValues);
+
+      // Simulate switching to edit mode
+      rerender({ editingItem: { id: '1', name: 'John', email: 'john@example.com', age: 25 } });
+
+      expect(result.current.values.name).toBe('John');
+      expect(result.current.values.email).toBe('john@example.com');
+      expect(result.current.values.age).toBe(25);
+      expect(result.current.isEditing).toBe(true);
+    });
+
+    it('should reset to initial values when editingItem becomes undefined', () => {
+      const editingItem = { id: '1', name: 'John', email: 'john@example.com', age: 25 };
+      const config = createMockConfig({ editingItem });
+      const { result, rerender } = renderHook(
+        ({ editingItem }) => useModalForm({ ...config, editingItem }),
+        {
+          wrapper: createWrapper(),
+          initialProps: { editingItem: editingItem as any },
+        }
+      );
+
+      expect(result.current.values.name).toBe('John');
+
+      // Simulate switching back to create mode
+      rerender({ editingItem: undefined });
+
+      expect(result.current.values).toEqual(defaultInitialValues);
+      expect(result.current.isEditing).toBe(false);
+    });
+
+    it('should clear errors when editingItem changes', () => {
+      const config = createMockConfig();
+      const { result, rerender } = renderHook(
+        ({ editingItem }) => useModalForm({ ...config, editingItem }),
+        {
+          wrapper: createWrapper(),
+          initialProps: { editingItem: undefined as any },
+        }
+      );
+
+      // Set some errors
+      act(() => {
+        result.current.setErrors({ name: 'Error', email: 'Error' });
+      });
+      expect(result.current.hasErrors).toBe(true);
+
+      // Switch to edit mode
+      rerender({ editingItem: { id: '1', name: 'John', email: '', age: 0 } });
+
+      expect(result.current.errors).toEqual({});
+      expect(result.current.hasErrors).toBe(false);
+    });
+  });
+});

--- a/client/src/hooks/useModalForm.ts
+++ b/client/src/hooks/useModalForm.ts
@@ -1,0 +1,238 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useMutation, useQueryClient, UseMutationResult } from '@tanstack/react-query';
+
+/**
+ * Validation function type - takes form values and returns an object with field-level errors
+ */
+export type ValidateFn<T> = (values: T) => Partial<Record<keyof T, string>>;
+
+/**
+ * Configuration for the useModalForm hook
+ */
+export interface UseModalFormConfig<T extends Record<string, any>, TResponse = any> {
+  /** Initial values for the form */
+  initialValues: T;
+  /** Validation function that returns field-level errors */
+  validate?: ValidateFn<T>;
+  /** API function to create a new record */
+  onCreate: (values: T) => Promise<TResponse>;
+  /** API function to update an existing record */
+  onUpdate: (id: string, values: T) => Promise<TResponse>;
+  /** Query keys to invalidate on success */
+  queryKeysToInvalidate: string[][];
+  /** Additional query keys to invalidate on update (e.g., for the specific entity) */
+  additionalUpdateQueryKeys?: (editingItem: any) => string[][];
+  /** Callback called on successful create/update */
+  onSuccess?: (data: TResponse, isEditing: boolean) => void;
+  /** Callback called on error */
+  onError?: (error: unknown, isEditing: boolean) => void;
+  /** Callback to close the modal */
+  onClose: () => void;
+  /** The item being edited (if editing mode) */
+  editingItem?: any;
+  /** Custom function to extract form values from editing item */
+  getValuesFromItem?: (item: any) => T;
+}
+
+/**
+ * Return type for useModalForm hook
+ */
+export interface UseModalFormReturn<T extends Record<string, any>> {
+  /** Current form values */
+  values: T;
+  /** Current field-level errors */
+  errors: Partial<Record<keyof T, string>>;
+  /** Whether the form has any errors */
+  hasErrors: boolean;
+  /** Whether we're in editing mode */
+  isEditing: boolean;
+  /** Whether a mutation is pending */
+  isSubmitting: boolean;
+  /** Handle input change for a single field */
+  handleChange: <K extends keyof T>(field: K, value: T[K]) => void;
+  /** Handle form submission */
+  handleSubmit: (e: React.FormEvent) => void;
+  /** Set multiple values at once */
+  setValues: React.Dispatch<React.SetStateAction<T>>;
+  /** Set errors manually */
+  setErrors: React.Dispatch<React.SetStateAction<Partial<Record<keyof T, string>>>>;
+  /** Reset form to initial values */
+  reset: () => void;
+  /** Handle close with animation delay */
+  handleClose: () => void;
+  /** Create mutation object for advanced usage */
+  createMutation: UseMutationResult<any, unknown, T, unknown>;
+  /** Update mutation object for advanced usage */
+  updateMutation: UseMutationResult<any, unknown, T, unknown>;
+}
+
+/**
+ * useModalForm - A reusable hook for modal form state, validation, and submission.
+ *
+ * Consolidates common patterns across modal components:
+ * - Form state management with useState
+ * - Validation with field-level errors
+ * - Create/update mutations with React Query
+ * - Automatic query invalidation on success
+ * - Form reset when editing item changes
+ *
+ * @example
+ * ```tsx
+ * const { values, errors, handleChange, handleSubmit, isSubmitting } = useModalForm({
+ *   initialValues: { name: '', email: '' },
+ *   validate: (values) => {
+ *     const errors = {};
+ *     if (!values.name) errors.name = 'Name is required';
+ *     if (!values.email) errors.email = 'Email is required';
+ *     return errors;
+ *   },
+ *   onCreate: (values) => api.users.create(values),
+ *   onUpdate: (id, values) => api.users.update(id, values),
+ *   queryKeysToInvalidate: [['users']],
+ *   onClose,
+ *   editingItem,
+ * });
+ * ```
+ */
+export function useModalForm<T extends Record<string, any>, TResponse = any>(
+  config: UseModalFormConfig<T, TResponse>
+): UseModalFormReturn<T> {
+  const {
+    initialValues,
+    validate,
+    onCreate,
+    onUpdate,
+    queryKeysToInvalidate,
+    additionalUpdateQueryKeys,
+    onSuccess,
+    onError,
+    onClose,
+    editingItem,
+    getValuesFromItem,
+  } = config;
+
+  const queryClient = useQueryClient();
+  const isEditing = !!editingItem;
+
+  // Form state
+  const [values, setValues] = useState<T>(initialValues);
+  const [errors, setErrors] = useState<Partial<Record<keyof T, string>>>({});
+
+  // Reset form when editingItem changes
+  useEffect(() => {
+    if (editingItem && getValuesFromItem) {
+      setValues(getValuesFromItem(editingItem));
+    } else if (editingItem) {
+      // Default behavior: extract matching keys from editingItem
+      const newValues = { ...initialValues };
+      for (const key of Object.keys(initialValues) as (keyof T)[]) {
+        if (editingItem[key] !== undefined) {
+          newValues[key] = editingItem[key];
+        }
+      }
+      setValues(newValues);
+    } else {
+      setValues(initialValues);
+    }
+    setErrors({});
+  }, [editingItem]);
+
+  // Create mutation
+  const createMutation = useMutation({
+    mutationFn: (data: T) => onCreate(data),
+    onSuccess: (data) => {
+      for (const queryKey of queryKeysToInvalidate) {
+        queryClient.invalidateQueries({ queryKey });
+      }
+      onSuccess?.(data, false);
+      onClose();
+    },
+    onError: (error) => {
+      console.error('Failed to create:', error);
+      onError?.(error, false);
+    },
+  });
+
+  // Update mutation
+  const updateMutation = useMutation({
+    mutationFn: (data: T) => onUpdate(editingItem?.id, data),
+    onSuccess: (data) => {
+      for (const queryKey of queryKeysToInvalidate) {
+        queryClient.invalidateQueries({ queryKey });
+      }
+      // Also invalidate additional query keys (e.g., for specific entity)
+      if (editingItem && additionalUpdateQueryKeys) {
+        for (const queryKey of additionalUpdateQueryKeys(editingItem)) {
+          queryClient.invalidateQueries({ queryKey });
+        }
+      }
+      onSuccess?.(data, true);
+      onClose();
+    },
+    onError: (error) => {
+      console.error('Failed to update:', error);
+      onError?.(error, true);
+    },
+  });
+
+  // Handle field change
+  const handleChange = useCallback(<K extends keyof T>(field: K, value: T[K]) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+    // Clear error for this field when user starts typing
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: '' }));
+    }
+  }, [errors]);
+
+  // Handle form submission
+  const handleSubmit = useCallback((e: React.FormEvent) => {
+    e.preventDefault();
+
+    // Run validation if provided
+    const newErrors = validate ? validate(values) : {};
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    setErrors({});
+    if (isEditing) {
+      updateMutation.mutate(values);
+    } else {
+      createMutation.mutate(values);
+    }
+  }, [values, validate, isEditing, createMutation, updateMutation]);
+
+  // Reset form to initial values
+  const reset = useCallback(() => {
+    setValues(initialValues);
+    setErrors({});
+  }, [initialValues]);
+
+  // Handle close with animation delay
+  const handleClose = useCallback(() => {
+    setTimeout(() => onClose(), 200);
+  }, [onClose]);
+
+  const hasErrors = Object.keys(errors).filter((key) => !!errors[key as keyof T]).length > 0;
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  return {
+    values,
+    errors,
+    hasErrors,
+    isEditing,
+    isSubmitting,
+    handleChange,
+    handleSubmit,
+    setValues,
+    setErrors,
+    reset,
+    handleClose,
+    createMutation,
+    updateMutation,
+  };
+}
+
+export default useModalForm;


### PR DESCRIPTION
## Summary
- Created `useModalForm` hook to consolidate duplicate form state management patterns across modal components
- Refactored 4 modal components to use the shared hook, reducing code duplication significantly
- The hook handles form state, validation, mutations, and query invalidation in a consistent way

## Changes Made
- **New file**: `client/src/hooks/useModalForm.ts` - Reusable hook for modal form state management
- **New file**: `client/src/hooks/__tests__/useModalForm.test.tsx` - Comprehensive tests (17 test cases)
- **Refactored**: `AssignmentModalNew.tsx` - Reduced ~40 lines using useModalForm
- **Refactored**: `ProjectModal.tsx` - Reduced ~65 lines using useModalForm  
- **Refactored**: `PersonModal.tsx` - Reduced ~65 lines using useModalForm
- **Cleaned up**: `PersonRoleModal.tsx` - Minor cleanup (kept simpler pattern due to non-standard API)

## Hook Features
- Form state management with `useState`
- Field-level validation with error messages
- Create/update mutations with React Query
- Automatic query invalidation on success
- Optional additional query keys for specific entity invalidation
- Form reset when editing item changes
- Type-safe with full TypeScript support

## Test Results
- All 496 modal-related tests passing
- 17 new tests for useModalForm hook
- All existing functionality preserved

## Testing Instructions
```bash
npm run test:client -- --testPathPatterns="Modal" --no-coverage
```

## Breaking Changes
None - This is a refactoring that maintains backward compatibility.

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>