### PR TITLE
feat: remove unsafe-inline from CSP scriptSrc directive (issue #48)

### DIFF
--- a/src/electron/settings-window.html
+++ b/src/electron/settings-window.html
@@ -152,11 +152,11 @@
     </div>
     
     <div class="tabs">
-        <button class="tab active" onclick="switchTab('general')">General</button>
-        <button class="tab" onclick="switchTab('database')">Database</button>
-        <button class="tab" onclick="switchTab('server')">Server</button>
-        <button class="tab" onclick="switchTab('backup')">Backup</button>
-        <button class="tab" onclick="switchTab('advanced')">Advanced</button>
+        <button class="tab active" data-tab="general">General</button>
+        <button class="tab" data-tab="database">Database</button>
+        <button class="tab" data-tab="server">Server</button>
+        <button class="tab" data-tab="backup">Backup</button>
+        <button class="tab" data-tab="advanced">Advanced</button>
     </div>
     
     <!-- General Tab -->
@@ -216,7 +216,7 @@
         </div>
         
         <div class="form-group">
-            <button class="btn btn-secondary" onclick="optimizeDatabase()">
+            <button class="btn btn-secondary" data-action="optimize-database">
                 Optimize Database
             </button>
             <p class="help-text">Compact and optimize database performance</p>
@@ -279,7 +279,7 @@
             <label>Backup Location</label>
             <div style="display: flex; gap: 10px;">
                 <input type="text" id="backupLocation" style="flex: 1;">
-                <button class="btn btn-secondary" onclick="browseBackupFolder()">Browse...</button>
+                <button class="btn btn-secondary" data-action="browse-backup">Browse...</button>
             </div>
         </div>
         
@@ -292,7 +292,7 @@
         <div class="form-group">
             <label>Last Backup</label>
             <p class="current-value" id="lastBackup">Never</p>
-            <button class="btn btn-secondary" onclick="backupNow()">Backup Now</button>
+            <button class="btn btn-secondary" data-action="backup-now">Backup Now</button>
         </div>
     </div>
     
@@ -312,7 +312,7 @@
         <div class="form-group">
             <label>Log File Location</label>
             <input type="text" id="logLocation" readonly>
-            <button class="btn btn-secondary" onclick="openLogFolder()">Open Folder</button>
+            <button class="btn btn-secondary" data-action="open-logs">Open Folder</button>
         </div>
         
         <div class="form-group">
@@ -337,14 +337,14 @@
         </div>
         
         <div class="form-group">
-            <button class="btn btn-secondary" onclick="clearCache()">Clear Cache</button>
-            <button class="btn btn-secondary" onclick="resetSettings()">Reset All Settings</button>
+            <button class="btn btn-secondary" data-action="clear-cache">Clear Cache</button>
+            <button class="btn btn-secondary" data-action="reset-settings">Reset All Settings</button>
         </div>
     </div>
     
     <div class="button-group">
-        <button class="btn btn-secondary" onclick="closeSettings()">Cancel</button>
-        <button class="btn btn-primary" onclick="saveSettings()">Save</button>
+        <button class="btn btn-secondary" data-action="close">Cancel</button>
+        <button class="btn btn-primary" data-action="save">Save</button>
     </div>
     
     <script src="settings-window.js"></script>

--- a/src/electron/settings-window.js
+++ b/src/electron/settings-window.js
@@ -8,6 +8,30 @@ window.addEventListener('DOMContentLoaded', async () => {
     loadSettings();
     calculateDatabaseSize();
     checkLastBackup();
+
+    // Tab switching listeners
+    document.querySelectorAll('[data-tab]').forEach(tab => {
+        tab.addEventListener('click', function() {
+            switchTab(this.dataset.tab);
+        });
+    });
+
+    // Button action listeners
+    document.querySelectorAll('[data-action]').forEach(btn => {
+        const action = btn.dataset.action;
+        btn.addEventListener('click', () => {
+            switch (action) {
+                case 'save': saveSettings(); break;
+                case 'close': closeSettings(); break;
+                case 'optimize-database': optimizeDatabase(); break;
+                case 'browse-backup': browseBackupFolder(); break;
+                case 'backup-now': backupNow(); break;
+                case 'open-logs': openLogFolder(); break;
+                case 'clear-cache': clearCache(); break;
+                case 'reset-settings': resetSettings(); break;
+            }
+        });
+    });
 });
 
 // Tab switching
@@ -15,9 +39,11 @@ function switchTab(tabName) {
     // Update tab buttons
     document.querySelectorAll('.tab').forEach(tab => {
         tab.classList.remove('active');
+        if (tab.dataset.tab === tabName) {
+            tab.classList.add('active');
+        }
     });
-    event.target.classList.add('active');
-    
+
     // Update tab content
     document.querySelectorAll('.tab-content').forEach(content => {
         content.classList.remove('active');

--- a/src/electron/setup-wizard.html
+++ b/src/electron/setup-wizard.html
@@ -305,7 +305,7 @@
             
             <div class="button-group">
                 <div></div>
-                <button class="btn btn-primary" onclick="nextStep()">Get Started →</button>
+                <button class="btn btn-primary" data-action="next">Get Started →</button>
             </div>
         </div>
         
@@ -318,7 +318,7 @@
                 <label for="dbLocation">Database Location</label>
                 <div class="input-group">
                     <input type="text" id="dbLocation" placeholder="Default: User data directory">
-                    <button class="btn btn-secondary" onclick="browseFolder()">Browse...</button>
+                    <button class="btn btn-secondary" data-action="browse">Browse...</button>
                 </div>
                 <p class="help-text">Leave empty to use the default location in your user data folder</p>
             </div>
@@ -353,11 +353,11 @@
             </div>
             
             <div class="button-group">
-                <button class="btn btn-secondary" onclick="previousStep()">← Back</button>
-                <button class="btn btn-primary" onclick="nextStep()">Next →</button>
+                <button class="btn btn-secondary" data-action="previous">← Back</button>
+                <button class="btn btn-primary" data-action="next">Next →</button>
             </div>
         </div>
-        
+
         <!-- Server Step -->
         <div class="step-content" id="server">
             <h1>Server Configuration</h1>
@@ -388,11 +388,11 @@
             </div>
             
             <div class="button-group">
-                <button class="btn btn-secondary" onclick="previousStep()">← Back</button>
-                <button class="btn btn-primary" onclick="nextStep()">Next →</button>
+                <button class="btn btn-secondary" data-action="previous">← Back</button>
+                <button class="btn btn-primary" data-action="next">Next →</button>
             </div>
         </div>
-        
+
         <!-- Advanced Step -->
         <div class="step-content" id="advanced">
             <h1>Advanced Settings</h1>
@@ -436,11 +436,11 @@
             </div>
             
             <div class="button-group">
-                <button class="btn btn-secondary" onclick="previousStep()">← Back</button>
-                <button class="btn btn-primary" onclick="nextStep()">Next →</button>
+                <button class="btn btn-secondary" data-action="previous">← Back</button>
+                <button class="btn btn-primary" data-action="next">Next →</button>
             </div>
         </div>
-        
+
         <!-- Review Step -->
         <div class="step-content" id="review">
             <h1>Review Configuration</h1>
@@ -454,8 +454,8 @@
             </div>
             
             <div class="button-group">
-                <button class="btn btn-secondary" onclick="previousStep()">← Back</button>
-                <button class="btn btn-primary" onclick="saveAndFinish()" id="finishBtn">
+                <button class="btn btn-secondary" data-action="previous">← Back</button>
+                <button class="btn btn-primary" id="finishBtn">
                     Save Configuration
                 </button>
             </div>

--- a/src/electron/setup-wizard.js
+++ b/src/electron/setup-wizard.js
@@ -32,7 +32,28 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('autoBackup').addEventListener('change', (e) => {
         document.getElementById('backupOptions').style.display = e.target.checked ? 'block' : 'none';
     });
-    
+
+    // Navigation button listeners
+    document.querySelectorAll('[data-action="next"]').forEach(btn => {
+        btn.addEventListener('click', nextStep);
+    });
+
+    document.querySelectorAll('[data-action="previous"]').forEach(btn => {
+        btn.addEventListener('click', previousStep);
+    });
+
+    // Browse folder button
+    const browseBtn = document.querySelector('[data-action="browse"]');
+    if (browseBtn) {
+        browseBtn.addEventListener('click', browseFolder);
+    }
+
+    // Finish/save button
+    const finishBtn = document.getElementById('finishBtn');
+    if (finishBtn) {
+        finishBtn.addEventListener('click', saveAndFinish);
+    }
+
     // Load default paths
     loadDefaults();
 });

--- a/src/server/api/routes/index.ts
+++ b/src/server/api/routes/index.ts
@@ -65,6 +65,28 @@ router.use('/test-data', testDataRoutes);
 // Test context routes (for per-test data isolation)
 router.use('/test-context', testContextRoutes);
 
+// CSP violation reporting endpoint
+router.post('/csp-report', (req: RequestWithLogging, res) => {
+  const report = req.body['csp-report'] || req.body;
+
+  if (report) {
+    req.logger.warn('CSP Violation Report', {
+      documentUri: report['document-uri'],
+      violatedDirective: report['violated-directive'],
+      effectiveDirective: report['effective-directive'],
+      blockedUri: report['blocked-uri'],
+      sourceFile: report['source-file'],
+      lineNumber: report['line-number'],
+      columnNumber: report['column-number'],
+      originalPolicy: report['original-policy'],
+      disposition: report.disposition,
+    });
+  }
+
+  // Return 204 No Content (standard for CSP reports)
+  res.status(204).end();
+});
+
 // Client logging endpoint for remote logging
 router.post('/client-logs', (req: RequestWithLogging, res) => {
   const { logs } = req.body;

--- a/tests/unit/server/app.test.ts
+++ b/tests/unit/server/app.test.ts
@@ -150,7 +150,8 @@ describe('Express App', () => {
       expect(app).toBe(mockApp);
     });
 
-    it('should configure helmet security middleware with CSP', async () => {
+    it('should configure helmet security middleware with CSP (production - no unsafe-eval)', async () => {
+      process.env.NODE_ENV = 'production';
       await createExpressApp();
 
       expect(mockHelmet).toHaveBeenCalledWith({
@@ -158,10 +159,32 @@ describe('Express App', () => {
           directives: {
             defaultSrc: ["'self'"],
             styleSrc: ["'self'", "'unsafe-inline'"],
-            scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+            scriptSrc: ["'self'"],
             imgSrc: ["'self'", "data:", "blob:"],
-            connectSrc: ["'self'"]
-          }
+            connectSrc: ["'self'"],
+            reportUri: ['/api/csp-report'],
+          },
+          reportOnly: false,
+        }
+      });
+      expect(mockUse).toHaveBeenCalledWith('helmet-middleware');
+    });
+
+    it('should configure helmet security middleware with CSP (development - with unsafe-eval)', async () => {
+      process.env.NODE_ENV = 'development';
+      await createExpressApp();
+
+      expect(mockHelmet).toHaveBeenCalledWith({
+        contentSecurityPolicy: {
+          directives: {
+            defaultSrc: ["'self'"],
+            styleSrc: ["'self'", "'unsafe-inline'"],
+            scriptSrc: ["'self'", "'unsafe-eval'"],
+            imgSrc: ["'self'", "data:", "blob:"],
+            connectSrc: ["'self'"],
+            reportUri: ['/api/csp-report'],
+          },
+          reportOnly: false,
         }
       });
       expect(mockUse).toHaveBeenCalledWith('helmet-middleware');


### PR DESCRIPTION
## Summary

- Removed `'unsafe-inline'` from CSP `scriptSrc` directive by externalizing all inline event handlers
- Kept `'unsafe-eval'` only in development mode (required for Vite HMR)
- Added CSP violation reporting endpoint for security monitoring

## Changes Made

### Electron HTML/JS Files
- Replaced inline `onclick="foo()"` handlers with `data-action="foo"` attributes
- Added event listeners in `DOMContentLoaded` handlers
- Updated `setup-wizard.html/js` and `settings-window.html/js`

### CSP Configuration (`src/server/app.ts`)
- Production: `scriptSrc: ["'self'"]` (no unsafe directives)
- Development: `scriptSrc: ["'self'", "'unsafe-eval'"]` (eval needed for Vite HMR)
- Kept `styleSrc: ["'self'", "'unsafe-inline'"]` (acceptable per OWASP guidelines)
- Added `reportUri: ['/api/csp-report']` for violation reporting

### CSP Violation Reporting
- Added `POST /api/csp-report` endpoint
- Logs violations with document URI, violated directive, blocked URI, source file, etc.
- Returns 204 No Content per CSP reporting standard

### Tests
- Updated `app.test.ts` with tests for both production and development CSP configurations
- Verifies `reportUri` directive is included

## Test Plan

- [x] Unit tests pass (`npm run test:server -- --testPathPatterns="app.test"`)
- [x] CSP configuration correctly varies by environment
- [x] CSP violation reporting endpoint logs violations
- [ ] Manual verification in browser DevTools network tab

## Security Improvement

This change improves the application's security posture by:
1. Eliminating XSS risk from inline script injection
2. Providing visibility into CSP violations via logging
3. Maintaining development ergonomics with conditional `unsafe-eval`

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)