### PR TITLE
feat: add Jest coverage configuration and thresholds (closes #39)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -100,5 +100,53 @@ module.exports = {
   ],
   
   // Module file extensions
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+
+  // Coverage configuration
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    'client/src/**/*.{ts,tsx}',
+    // Exclude type definition files
+    '!**/*.d.ts',
+    // Exclude node_modules
+    '!**/node_modules/**',
+    // Exclude test files
+    '!**/__tests__/**',
+    '!**/tests/**',
+    // Exclude build output
+    '!**/dist/**',
+    '!**/build/**',
+    // Exclude config files
+    '!**/*.config.{ts,js,cjs}',
+    // Exclude index/barrel files (often just re-exports)
+    '!**/index.ts',
+    // Exclude migrations (database schema, not application logic)
+    '!**/migrations/**',
+    // Exclude Electron main process (separate runtime)
+    '!src/electron/**'
+  ],
+
+  // Coverage thresholds - baselines based on current coverage levels
+  // Current coverage (as of initial setup):
+  //   Statements: 49.46%, Branches: 48.77%, Functions: 43.04%, Lines: 50.81%
+  // These thresholds prevent regression and can be increased incrementally
+  coverageThreshold: {
+    global: {
+      branches: 45,
+      functions: 40,
+      lines: 45,
+      statements: 45
+    }
+  },
+
+  // Coverage output directory
+  coverageDirectory: '<rootDir>/coverage',
+
+  // Coverage report formats
+  coverageReporters: [
+    'text',           // Console output
+    'text-summary',   // Condensed console summary
+    'lcov',           // HTML report + lcov.info for CI tools
+    'json'            // JSON for programmatic access
+  ]
 };

--- a/jest.config.client.cjs
+++ b/jest.config.client.cjs
@@ -40,5 +40,45 @@ module.exports = {
   
   // Setup files
   setupFiles: ['<rootDir>/tests/setup.client.js'],
-  setupFilesAfterEnv: ['@testing-library/jest-dom']
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
+
+  // Coverage configuration (client-specific)
+  collectCoverageFrom: [
+    'client/src/**/*.{ts,tsx}',
+    // Exclude type definition files
+    '!**/*.d.ts',
+    // Exclude node_modules
+    '!**/node_modules/**',
+    // Exclude test files
+    '!**/__tests__/**',
+    // Exclude build output
+    '!**/dist/**',
+    '!**/build/**',
+    // Exclude config files
+    '!**/*.config.{ts,js,cjs}',
+    // Exclude index/barrel files (often just re-exports)
+    '!**/index.ts'
+  ],
+
+  // Coverage thresholds - baselines to prevent regression
+  // These can be increased incrementally as coverage improves
+  coverageThreshold: {
+    global: {
+      branches: 45,
+      functions: 40,
+      lines: 45,
+      statements: 45
+    }
+  },
+
+  // Coverage output directory
+  coverageDirectory: '<rootDir>/coverage/client',
+
+  // Coverage report formats
+  coverageReporters: [
+    'text',
+    'text-summary',
+    'lcov',
+    'json'
+  ]
 };


### PR DESCRIPTION
## Summary
Add comprehensive Jest coverage configuration to enable coverage collection, reporting, and threshold enforcement for the test suite.

## Changes Made
- **jest.config.cjs**: Added coverage configuration including:
  - `collectCoverageFrom` patterns for src/ and client/src/
  - Exclusions for tests, configs, migrations, build artifacts, and Electron
  - `coverageThreshold` with baselines: 45% statements/branches/lines, 40% functions
  - `coverageDirectory` for output location
  - Multiple `coverageReporters`: text, text-summary, lcov, json

- **jest.config.client.cjs**: Added equivalent coverage configuration for client-only test runs

## Current Baseline Coverage (server-unit tests)
- Statements: 49.46%
- Branches: 48.77%
- Functions: 43.04%
- Lines: 50.81%

## Test Results
- All tests passing
- Coverage thresholds verified: CI will now fail if coverage drops below thresholds

## Testing Instructions
```bash
npm test -- --coverage
npx jest --selectProjects server-unit --coverage
```

## Breaking Changes
None

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>