### PR TITLE
feat: add input validation with proper radix and type coercion (closes #50)

### DIFF
--- a/client/src/components/PhaseTimeline.tsx
+++ b/client/src/components/PhaseTimeline.tsx
@@ -1087,7 +1087,7 @@ export function PhaseTimeline({ projectId, projectName }: PhaseTimelineProps) {
                       value={dependencyForm.lag_days}
                       onChange={(e) => setDependencyForm(prev => ({ 
                         ...prev, 
-                        lag_days: parseInt(e.target.value) || 0
+                        lag_days: parseInt(e.target.value, 10) || 0
                       }))}
                       className="form-input"
                       min="0"

--- a/client/src/components/VisualPhaseManager.tsx
+++ b/client/src/components/VisualPhaseManager.tsx
@@ -1269,7 +1269,7 @@ export function VisualPhaseManager({ projectId, projectName, onPhasesChange, com
                 <input
                   type="number"
                   value={dependencyForm.lag_days}
-                  onChange={(e) => setDependencyForm(prev => ({ ...prev, lag_days: parseInt(e.target.value) || 0 }))}
+                  onChange={(e) => setDependencyForm(prev => ({ ...prev, lag_days: parseInt(e.target.value, 10) || 0 }))}
                   min="-365"
                   max="365"
                   className="form-input"

--- a/client/src/components/modals/AssignmentModalNew.tsx
+++ b/client/src/components/modals/AssignmentModalNew.tsx
@@ -317,7 +317,7 @@ export const AssignmentModalNew: React.FC<AssignmentModalProps> = ({
                 type="number"
                 id="allocation_percentage"
                 value={formData.allocation_percentage}
-                onChange={(e) => handleChange('allocation_percentage', parseInt(e.target.value) || 0)}
+                onChange={(e) => handleChange('allocation_percentage', parseInt(e.target.value, 10) || 0)}
                 min="1"
                 max="100"
                 className={errors.allocation_percentage ? 'border-red-500' : ''}

--- a/client/src/components/modals/PersonRoleModal.tsx
+++ b/client/src/components/modals/PersonRoleModal.tsx
@@ -100,7 +100,7 @@ export default function PersonRoleModal({
     try {
       const submitData = {
         role_id: formData.role_id,
-        proficiency_level: parseInt(formData.proficiency_level),
+        proficiency_level: parseInt(formData.proficiency_level, 10),
         is_primary: formData.is_primary,
         start_date: formData.start_date || null,
         end_date: formData.end_date || null

--- a/client/src/components/modals/SmartAssignmentModal.tsx
+++ b/client/src/components/modals/SmartAssignmentModal.tsx
@@ -953,7 +953,7 @@ export function SmartAssignmentModal({
                     max="100"
                     step="5"
                     value={formData.allocation_percentage}
-                    onChange={(e) => handleFormChange('allocation_percentage', parseInt(e.target.value))}
+                    onChange={(e) => handleFormChange('allocation_percentage', parseInt(e.target.value, 10))}
                     className="allocation-slider"
                   />
                   <div className="allocation-guide">

--- a/client/src/components/modals/__tests__/PersonRoleModal.test.tsx
+++ b/client/src/components/modals/__tests__/PersonRoleModal.test.tsx
@@ -413,8 +413,8 @@ describe('PersonRoleModal', () => {
     it('converts proficiency_level to integer', async () => {
       // This tests the business logic in handleSubmit
       // The conversion happens in the submit handler
-      expect(parseInt('3')).toBe(3);
-      expect(parseInt('5')).toBe(5);
+      expect(parseInt('3', 10)).toBe(3);
+      expect(parseInt('5', 10)).toBe(5);
     });
 
     it('converts empty dates to null', () => {

--- a/client/src/components/modals/__tests__/SmartAssignmentModal.test.tsx
+++ b/client/src/components/modals/__tests__/SmartAssignmentModal.test.tsx
@@ -1299,7 +1299,7 @@ describe('SmartAssignmentModal', () => {
 
         // Verify slider was auto-adjusted to remaining capacity (10%)
         await waitFor(() => {
-          const sliderValue = parseInt(slider.getAttribute('value') || '0');
+          const sliderValue = parseInt(slider.getAttribute('value') || '0', 10);
           expect(sliderValue).toBeLessThanOrEqual(10); // Auto-adjusted to not exceed capacity
         });
 
@@ -1338,7 +1338,7 @@ describe('SmartAssignmentModal', () => {
         // Should auto-adjust to not exceed 100%
         await waitFor(() => {
           const slider = screen.getByRole('slider');
-          const sliderValue = parseInt(slider.getAttribute('value') || '0');
+          const sliderValue = parseInt(slider.getAttribute('value') || '0', 10);
           expect(sliderValue).toBeLessThanOrEqual(10); // Remaining capacity is 5%, should be capped
         });
       });

--- a/client/src/pages/AssignmentNew.tsx
+++ b/client/src/pages/AssignmentNew.tsx
@@ -55,7 +55,7 @@ export function AssignmentNew() {
       status,
       startDate,
       endDate,
-      allocation: allocation ? parseInt(allocation) : null,
+      allocation: allocation ? parseInt(allocation, 10) : null,
       hasContext: !!(person || role || project || action)
     };
   }, [searchParams]);
@@ -491,7 +491,7 @@ export function AssignmentNew() {
                   <input
                     type="number"
                     value={formData.allocation_percentage}
-                    onChange={(e) => handleChange('allocation_percentage', parseInt(e.target.value))}
+                    onChange={(e) => handleChange('allocation_percentage', parseInt(e.target.value, 10))}
                     className={`form-input ${errors.allocation_percentage ? 'error' : ''}`}
                     min="1"
                     max="100"

--- a/client/src/pages/Availability.tsx
+++ b/client/src/pages/Availability.tsx
@@ -399,7 +399,7 @@ export default function Availability() {
                   <input
                     type="number"
                     value={formData.hours_per_day}
-                    onChange={(e) => setFormData({...formData, hours_per_day: parseInt(e.target.value) || 0})}
+                    onChange={(e) => setFormData({...formData, hours_per_day: parseInt(e.target.value, 10) || 0})}
                     className="form-input"
                     min="0"
                     max="8"

--- a/client/src/pages/Import.tsx
+++ b/client/src/pages/Import.tsx
@@ -379,7 +379,7 @@ export default function Import() {
                           value={settingsOverrides.defaultProjectPriority ?? importSettings.defaultProjectPriority}
                           onChange={(e) => setSettingsOverrides({
                             ...settingsOverrides,
-                            defaultProjectPriority: parseInt(e.target.value)
+                            defaultProjectPriority: parseInt(e.target.value, 10)
                           })}
                           disabled={uploading}
                           className="form-select"

--- a/client/src/pages/ImportUnified.tsx
+++ b/client/src/pages/ImportUnified.tsx
@@ -395,7 +395,7 @@ function ImportUnified() {
                           value={settingsOverrides.defaultProjectPriority ?? importSettings.defaultProjectPriority}
                           onChange={(e) => setSettingsOverrides({
                             ...settingsOverrides,
-                            defaultProjectPriority: parseInt(e.target.value)
+                            defaultProjectPriority: parseInt(e.target.value, 10)
                           })}
                           disabled={uploading}
                           className="form-select"

--- a/client/src/pages/PersonDetails.tsx
+++ b/client/src/pages/PersonDetails.tsx
@@ -406,7 +406,7 @@ export default function PersonDetails() {
 
     const handleSave = () => {
       if (editValue !== value) {
-        handleFieldUpdate(field, type === 'number' ? parseInt(editValue) : editValue);
+        handleFieldUpdate(field, type === 'number' ? parseInt(editValue, 10) : editValue);
       }
       setIsEditing(false);
     };
@@ -1016,7 +1016,7 @@ export default function PersonDetails() {
                         <input
                           type="number"
                           value={newTimeOffData?.availability_percentage || ''}
-                          onChange={(e) => setNewTimeOffData({ ...newTimeOffData, availability_percentage: parseInt(e.target.value) })}
+                          onChange={(e) => setNewTimeOffData({ ...newTimeOffData, availability_percentage: parseInt(e.target.value, 10) })}
                           className="form-input"
                           min="0"
                           max="100"

--- a/client/src/pages/PersonNew.tsx
+++ b/client/src/pages/PersonNew.tsx
@@ -344,7 +344,7 @@ export function PersonNew() {
                   <input
                     type="number"
                     value={formData.default_availability_percentage}
-                    onChange={(e) => handleChange('default_availability_percentage', parseInt(e.target.value))}
+                    onChange={(e) => handleChange('default_availability_percentage', parseInt(e.target.value, 10))}
                     className="form-input"
                     min="0"
                     max="100"
@@ -356,7 +356,7 @@ export function PersonNew() {
                   <input
                     type="number"
                     value={formData.default_hours_per_day}
-                    onChange={(e) => handleChange('default_hours_per_day', parseInt(e.target.value))}
+                    onChange={(e) => handleChange('default_hours_per_day', parseInt(e.target.value, 10))}
                     className="form-input"
                     min="0"
                     max="12"

--- a/client/src/pages/ProjectDetail.tsx
+++ b/client/src/pages/ProjectDetail.tsx
@@ -194,7 +194,7 @@ export function ProjectDetail() {
     updateAssignmentMutation.mutate({
       assignmentId: selectedAssignment.id,
       updates: {
-        allocation_percentage: parseInt(assignmentForm.allocation_percentage.toString()),
+        allocation_percentage: parseInt(assignmentForm.allocation_percentage.toString(), 10),
         start_date: new Date(assignmentForm.start_date).getTime(),
         end_date: new Date(assignmentForm.end_date).getTime()
       }
@@ -216,7 +216,7 @@ export function ProjectDetail() {
     if (field === 'include_in_demand') {
       handleFieldUpdate(field, value ? 1 : 0);
     } else if (typeof value === 'string' && ['priority'].includes(field)) {
-      handleFieldUpdate(field, parseInt(value));
+      handleFieldUpdate(field, parseInt(value, 10));
     } else {
       handleFieldUpdate(field, value);
     }
@@ -566,7 +566,7 @@ export function ProjectDetail() {
                         value={assignmentForm.allocation_percentage}
                         onChange={(e) => setAssignmentForm(prev => ({
                           ...prev,
-                          allocation_percentage: parseInt(e.target.value) || 0
+                          allocation_percentage: parseInt(e.target.value, 10) || 0
                         }))}
                         className="form-input"
                         required

--- a/client/src/pages/ProjectNew.tsx
+++ b/client/src/pages/ProjectNew.tsx
@@ -259,7 +259,7 @@ export function ProjectNew() {
                   <label>Priority</label>
                   <select
                     value={formData.priority}
-                    onChange={(e) => handleChange('priority', parseInt(e.target.value))}
+                    onChange={(e) => handleChange('priority', parseInt(e.target.value, 10))}
                     className="form-select"
                   >
                     <option value={1}>Critical</option>

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -16,7 +16,7 @@ import { getDefaultReportDateRange } from '../utils/date';
 const formatMonthYear = (monthStr: string): string => {
   if (!monthStr || !monthStr.includes('-')) return monthStr;
   const [year, month] = monthStr.split('-');
-  const date = new Date(parseInt(year), parseInt(month) - 1);
+  const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1);
   return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
 };
 import {
@@ -998,7 +998,7 @@ export default function Reports() {
                           <button
                             onClick={async () => {
                               const allocationInput = document.getElementById(`allocation-${project.id}`) as HTMLInputElement;
-                              const allocation = parseInt(allocationInput.value) || project.suggestedAllocation;
+                              const allocation = parseInt(allocationInput.value, 10) || project.suggestedAllocation;
                               
                               try {
                                 // Validate allocation fits within available capacity

--- a/client/src/pages/ReportsTabContent.tsx
+++ b/client/src/pages/ReportsTabContent.tsx
@@ -38,7 +38,7 @@ interface ReportFilters {
 const formatMonthYear = (monthStr: string): string => {
   if (!monthStr || !monthStr.includes('-')) return monthStr;
   const [year, month] = monthStr.split('-');
-  const date = new Date(parseInt(year), parseInt(month) - 1);
+  const date = new Date(parseInt(year, 10), parseInt(month, 10) - 1);
   return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
 };
 

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -182,7 +182,7 @@ export default function Settings() {
               <input
                 type="number"
                 value={systemSettings.defaultWorkHoursPerWeek}
-                onChange={(e) => setSystemSettings({...systemSettings, defaultWorkHoursPerWeek: parseInt(e.target.value) || 40})}
+                onChange={(e) => setSystemSettings({...systemSettings, defaultWorkHoursPerWeek: parseInt(e.target.value, 10) || 40})}
                 className="form-input"
                 min="1"
                 max="80"
@@ -194,7 +194,7 @@ export default function Settings() {
               <input
                 type="number"
                 value={systemSettings.defaultVacationDaysPerYear}
-                onChange={(e) => setSystemSettings({...systemSettings, defaultVacationDaysPerYear: parseInt(e.target.value) || 0})}
+                onChange={(e) => setSystemSettings({...systemSettings, defaultVacationDaysPerYear: parseInt(e.target.value, 10) || 0})}
                 className="form-input"
                 min="0"
                 max="365"
@@ -206,7 +206,7 @@ export default function Settings() {
             <label>Fiscal Year Start Month</label>
             <select
               value={systemSettings.fiscalYearStartMonth}
-              onChange={(e) => setSystemSettings({...systemSettings, fiscalYearStartMonth: parseInt(e.target.value)})}
+              onChange={(e) => setSystemSettings({...systemSettings, fiscalYearStartMonth: parseInt(e.target.value, 10)})}
               className="form-select"
             >
               {['January', 'February', 'March', 'April', 'May', 'June', 
@@ -236,7 +236,7 @@ export default function Settings() {
               <input
                 type="number"
                 value={systemSettings.maxAllocationPercentage}
-                onChange={(e) => setSystemSettings({...systemSettings, maxAllocationPercentage: parseInt(e.target.value) || 100})}
+                onChange={(e) => setSystemSettings({...systemSettings, maxAllocationPercentage: parseInt(e.target.value, 10) || 100})}
                 className="form-input"
                 min="100"
                 max="200"
@@ -360,7 +360,7 @@ export default function Settings() {
               <label>Default Project Priority</label>
               <select
                 value={importSettings.defaultProjectPriority}
-                onChange={(e) => setImportSettings({...importSettings, defaultProjectPriority: parseInt(e.target.value)})}
+                onChange={(e) => setImportSettings({...importSettings, defaultProjectPriority: parseInt(e.target.value, 10)})}
                 className="form-select"
               >
                 <option value={1}>🔴 High</option>

--- a/client/src/utils/__tests__/date.test.ts
+++ b/client/src/utils/__tests__/date.test.ts
@@ -271,7 +271,7 @@ describe('date.ts - Report Date Range', () => {
 
     it('returns date range ending ~12 months from now', () => {
       const range = getDefaultReportDateRange();
-      const endYear = parseInt(range.endDate.split('-')[0]);
+      const endYear = parseInt(range.endDate.split('-')[0], 10);
       const currentYear = new Date().getFullYear();
       expect(endYear).toBeGreaterThanOrEqual(currentYear);
       expect(endYear).toBeLessThanOrEqual(currentYear + 2);

--- a/client/src/utils/__tests__/validation.test.ts
+++ b/client/src/utils/__tests__/validation.test.ts
@@ -1,0 +1,329 @@
+import {
+  parseIntSafe,
+  parseFloatSafe,
+  validateNumericRange,
+  parseIntInRange,
+  validateDateFormat,
+  validateDateRange,
+  validateEmail,
+  validateRequired,
+  validateStringLength,
+  validateEnum,
+  parseAllocation,
+  parsePriority,
+  parseHoursPerDay,
+  parsePagination,
+  VALIDATION_CONSTANTS,
+} from '../validation';
+
+describe('parseIntSafe', () => {
+  it('should parse valid integer strings', () => {
+    expect(parseIntSafe('42')).toBe(42);
+    expect(parseIntSafe('0')).toBe(0);
+    expect(parseIntSafe('-10')).toBe(-10);
+    expect(parseIntSafe('  123  ')).toBe(123);
+  });
+
+  it('should use radix 10 (not octal)', () => {
+    // Without radix, "08" could be parsed as 0 (octal)
+    expect(parseIntSafe('08')).toBe(8);
+    expect(parseIntSafe('09')).toBe(9);
+    expect(parseIntSafe('010')).toBe(10);
+  });
+
+  it('should return default for invalid inputs', () => {
+    expect(parseIntSafe('invalid')).toBe(0);
+    expect(parseIntSafe('invalid', 5)).toBe(5);
+    expect(parseIntSafe('')).toBe(0);
+    expect(parseIntSafe('   ', 10)).toBe(10);
+  });
+
+  it('should handle null and undefined', () => {
+    expect(parseIntSafe(null)).toBe(0);
+    expect(parseIntSafe(undefined)).toBe(0);
+    expect(parseIntSafe(null, 99)).toBe(99);
+  });
+
+  it('should handle number inputs', () => {
+    expect(parseIntSafe(42)).toBe(42);
+    expect(parseIntSafe(3.14)).toBe(3);
+    expect(parseIntSafe(NaN, 5)).toBe(5);
+    expect(parseIntSafe(Infinity, 5)).toBe(5);
+  });
+
+  it('should handle mixed inputs', () => {
+    expect(parseIntSafe('3.14')).toBe(3);
+    expect(parseIntSafe('123abc')).toBe(123);
+  });
+});
+
+describe('parseFloatSafe', () => {
+  it('should parse valid float strings', () => {
+    expect(parseFloatSafe('3.14')).toBe(3.14);
+    expect(parseFloatSafe('0.5')).toBe(0.5);
+    expect(parseFloatSafe('-1.5')).toBe(-1.5);
+  });
+
+  it('should return default for invalid inputs', () => {
+    expect(parseFloatSafe('invalid')).toBe(0);
+    expect(parseFloatSafe('invalid', 1.5)).toBe(1.5);
+    expect(parseFloatSafe('')).toBe(0);
+  });
+
+  it('should handle null and undefined', () => {
+    expect(parseFloatSafe(null)).toBe(0);
+    expect(parseFloatSafe(undefined, 2.5)).toBe(2.5);
+  });
+
+  it('should handle number inputs', () => {
+    expect(parseFloatSafe(3.14)).toBe(3.14);
+    expect(parseFloatSafe(NaN, 5)).toBe(5);
+  });
+});
+
+describe('validateNumericRange', () => {
+  it('should validate values within range', () => {
+    const result = validateNumericRange(50, 0, 100);
+    expect(result.isValid).toBe(true);
+    expect(result.value).toBe(50);
+  });
+
+  it('should clamp values below minimum', () => {
+    const result = validateNumericRange(-10, 0, 100);
+    expect(result.isValid).toBe(false);
+    expect(result.value).toBe(0);
+    expect(result.error).toContain('at least 0');
+  });
+
+  it('should clamp values above maximum', () => {
+    const result = validateNumericRange(150, 0, 100);
+    expect(result.isValid).toBe(false);
+    expect(result.value).toBe(100);
+    expect(result.error).toContain('at most 100');
+  });
+
+  it('should handle edge cases', () => {
+    expect(validateNumericRange(0, 0, 100).isValid).toBe(true);
+    expect(validateNumericRange(100, 0, 100).isValid).toBe(true);
+    expect(validateNumericRange(NaN, 0, 100).isValid).toBe(false);
+  });
+});
+
+describe('parseIntInRange', () => {
+  it('should parse and clamp values', () => {
+    expect(parseIntInRange('50', 0, 100)).toBe(50);
+    expect(parseIntInRange('150', 0, 100)).toBe(100);
+    expect(parseIntInRange('-10', 0, 100)).toBe(0);
+  });
+
+  it('should use default for invalid input', () => {
+    expect(parseIntInRange('invalid', 0, 100, 50)).toBe(50);
+    expect(parseIntInRange(null, 0, 100)).toBe(0);
+  });
+});
+
+describe('validateDateFormat', () => {
+  it('should validate ISO date format', () => {
+    const result = validateDateFormat('2024-12-15');
+    expect(result.isValid).toBe(true);
+    expect(result.value).toBe('2024-12-15');
+    expect(result.date).toBeInstanceOf(Date);
+  });
+
+  it('should reject invalid format', () => {
+    const result = validateDateFormat('12/15/2024');
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('Invalid date format');
+  });
+
+  it('should reject invalid dates', () => {
+    const result = validateDateFormat('2024-02-30');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('should handle null and undefined', () => {
+    expect(validateDateFormat(null).isValid).toBe(false);
+    expect(validateDateFormat(undefined).isValid).toBe(false);
+  });
+
+  it('should validate US date format', () => {
+    const result = validateDateFormat('12/15/2024', 'US_DATE');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('should validate fiscal week format', () => {
+    const result = validateDateFormat('24FW36', 'FISCAL_WEEK');
+    expect(result.isValid).toBe(true);
+    expect(result.value).toBe('24FW36');
+  });
+});
+
+describe('validateDateRange', () => {
+  it('should validate valid date ranges', () => {
+    const result = validateDateRange('2024-01-01', '2024-12-31');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('should validate same start and end date', () => {
+    const result = validateDateRange('2024-06-15', '2024-06-15');
+    expect(result.isValid).toBe(true);
+  });
+
+  it('should reject end before start', () => {
+    const result = validateDateRange('2024-12-31', '2024-01-01');
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('before or equal');
+  });
+
+  it('should reject invalid dates', () => {
+    expect(validateDateRange('invalid', '2024-01-01').isValid).toBe(false);
+    expect(validateDateRange('2024-01-01', 'invalid').isValid).toBe(false);
+  });
+});
+
+describe('validateEmail', () => {
+  it('should validate valid emails', () => {
+    expect(validateEmail('test@example.com').isValid).toBe(true);
+    expect(validateEmail('user.name@domain.co.uk').isValid).toBe(true);
+  });
+
+  it('should reject invalid emails', () => {
+    expect(validateEmail('invalid').isValid).toBe(false);
+    expect(validateEmail('test@').isValid).toBe(false);
+    expect(validateEmail('@example.com').isValid).toBe(false);
+  });
+
+  it('should handle null and undefined', () => {
+    expect(validateEmail(null).isValid).toBe(false);
+    expect(validateEmail(undefined).isValid).toBe(false);
+  });
+});
+
+describe('validateRequired', () => {
+  it('should validate non-empty strings', () => {
+    expect(validateRequired('test').isValid).toBe(true);
+    expect(validateRequired('  valid  ').isValid).toBe(true);
+  });
+
+  it('should reject empty strings', () => {
+    expect(validateRequired('').isValid).toBe(false);
+    expect(validateRequired('   ').isValid).toBe(false);
+  });
+
+  it('should handle null and undefined', () => {
+    expect(validateRequired(null).isValid).toBe(false);
+    expect(validateRequired(undefined).isValid).toBe(false);
+  });
+
+  it('should include field name in error', () => {
+    const result = validateRequired('', 'Username');
+    expect(result.error).toContain('Username');
+  });
+});
+
+describe('validateStringLength', () => {
+  it('should validate within length constraints', () => {
+    expect(validateStringLength('test', 1, 10).isValid).toBe(true);
+  });
+
+  it('should reject too short strings', () => {
+    const result = validateStringLength('ab', 3, 10);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('at least 3');
+  });
+
+  it('should reject too long strings', () => {
+    const result = validateStringLength('this is too long', 1, 5);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('at most 5');
+  });
+});
+
+describe('validateEnum', () => {
+  const allowedValues = ['active', 'inactive', 'pending'] as const;
+
+  it('should validate allowed values', () => {
+    expect(validateEnum('active', allowedValues).isValid).toBe(true);
+    expect(validateEnum('inactive', allowedValues).isValid).toBe(true);
+  });
+
+  it('should reject invalid values', () => {
+    const result = validateEnum('unknown', allowedValues);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain('must be one of');
+  });
+
+  it('should handle null and undefined', () => {
+    expect(validateEnum(null, allowedValues).isValid).toBe(false);
+    expect(validateEnum(undefined, allowedValues).isValid).toBe(false);
+  });
+});
+
+describe('Helper functions', () => {
+  describe('parseAllocation', () => {
+    it('should parse and clamp allocation', () => {
+      expect(parseAllocation('50')).toBe(50);
+      expect(parseAllocation('150')).toBe(100);
+      expect(parseAllocation('-10')).toBe(0);
+      expect(parseAllocation('invalid')).toBe(50); // default
+    });
+  });
+
+  describe('parsePriority', () => {
+    it('should parse and clamp priority', () => {
+      expect(parsePriority('3')).toBe(3);
+      expect(parsePriority('10')).toBe(5);
+      expect(parsePriority('0')).toBe(1);
+      expect(parsePriority('invalid')).toBe(3); // default
+    });
+  });
+
+  describe('parseHoursPerDay', () => {
+    it('should parse and clamp hours', () => {
+      expect(parseHoursPerDay('8')).toBe(8);
+      expect(parseHoursPerDay('30')).toBe(24);
+      expect(parseHoursPerDay('-1')).toBe(0);
+      expect(parseHoursPerDay('invalid')).toBe(8); // default
+    });
+  });
+
+  describe('parsePagination', () => {
+    it('should parse pagination parameters', () => {
+      const result = parsePagination('2', '25');
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(25);
+    });
+
+    it('should use defaults for invalid input', () => {
+      const result = parsePagination(null, null);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(50);
+    });
+
+    it('should clamp values', () => {
+      const result = parsePagination('0', '5000');
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(1000);
+    });
+  });
+});
+
+describe('VALIDATION_CONSTANTS', () => {
+  it('should have expected allocation values', () => {
+    expect(VALIDATION_CONSTANTS.MIN_ALLOCATION).toBe(0);
+    expect(VALIDATION_CONSTANTS.MAX_ALLOCATION).toBe(100);
+    expect(VALIDATION_CONSTANTS.DEFAULT_ALLOCATION).toBe(50);
+  });
+
+  it('should have expected priority values', () => {
+    expect(VALIDATION_CONSTANTS.MIN_PRIORITY).toBe(1);
+    expect(VALIDATION_CONSTANTS.MAX_PRIORITY).toBe(5);
+    expect(VALIDATION_CONSTANTS.DEFAULT_PRIORITY).toBe(3);
+  });
+
+  it('should have expected pagination values', () => {
+    expect(VALIDATION_CONSTANTS.DEFAULT_PAGE).toBe(1);
+    expect(VALIDATION_CONSTANTS.DEFAULT_PAGE_SIZE).toBe(50);
+    expect(VALIDATION_CONSTANTS.MAX_PAGE_SIZE).toBe(1000);
+  });
+});

--- a/client/src/utils/dateUtils.ts
+++ b/client/src/utils/dateUtils.ts
@@ -26,7 +26,7 @@ export function parseDate(dateInput: string | number): Date {
       return new Date(dateInput + 'T00:00:00');
     } else if (dateInput.match(/^\d+$/)) {
       // String that looks like a timestamp
-      return new Date(parseInt(dateInput));
+      return new Date(parseInt(dateInput, 10));
     } else {
       // Other string formats
       return new Date(dateInput);

--- a/client/src/utils/validation.ts
+++ b/client/src/utils/validation.ts
@@ -1,0 +1,485 @@
+/**
+ * Input Validation Utilities
+ *
+ * Provides safe parsing and validation functions for form inputs
+ * to prevent bugs from improper type coercion and invalid data.
+ */
+
+/**
+ * Safely parse an integer with proper radix and fallback handling.
+ * Always uses radix 10 to avoid octal/hex interpretation issues.
+ *
+ * @param value - The value to parse (string, number, null, or undefined)
+ * @param defaultValue - The fallback value if parsing fails
+ * @returns The parsed integer or the default value
+ *
+ * @example
+ * parseIntSafe('42') // 42
+ * parseIntSafe('invalid') // 0
+ * parseIntSafe('invalid', 10) // 10
+ * parseIntSafe(null, 5) // 5
+ * parseIntSafe('08') // 8 (not 0 as with octal)
+ */
+export function parseIntSafe(
+  value: string | number | null | undefined,
+  defaultValue: number = 0
+): number {
+  if (value === null || value === undefined || value === '') {
+    return defaultValue;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? Math.floor(value) : defaultValue;
+  }
+
+  const trimmed = String(value).trim();
+  if (trimmed === '') {
+    return defaultValue;
+  }
+
+  const parsed = parseInt(trimmed, 10);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+/**
+ * Safely parse a float with fallback handling.
+ *
+ * @param value - The value to parse
+ * @param defaultValue - The fallback value if parsing fails
+ * @returns The parsed float or the default value
+ *
+ * @example
+ * parseFloatSafe('3.14') // 3.14
+ * parseFloatSafe('invalid') // 0
+ * parseFloatSafe('invalid', 1.5) // 1.5
+ */
+export function parseFloatSafe(
+  value: string | number | null | undefined,
+  defaultValue: number = 0
+): number {
+  if (value === null || value === undefined || value === '') {
+    return defaultValue;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : defaultValue;
+  }
+
+  const trimmed = String(value).trim();
+  if (trimmed === '') {
+    return defaultValue;
+  }
+
+  const parsed = parseFloat(trimmed);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+/**
+ * Validate that a number is within a specified range.
+ *
+ * @param value - The value to validate
+ * @param min - Minimum allowed value (inclusive)
+ * @param max - Maximum allowed value (inclusive)
+ * @returns An object with isValid flag and the clamped value
+ *
+ * @example
+ * validateNumericRange(50, 0, 100) // { isValid: true, value: 50 }
+ * validateNumericRange(150, 0, 100) // { isValid: false, value: 100 }
+ * validateNumericRange(-10, 0, 100) // { isValid: false, value: 0 }
+ */
+export function validateNumericRange(
+  value: number,
+  min: number,
+  max: number
+): { isValid: boolean; value: number; error?: string } {
+  if (!Number.isFinite(value)) {
+    return {
+      isValid: false,
+      value: min,
+      error: 'Value must be a valid number',
+    };
+  }
+
+  if (value < min) {
+    return {
+      isValid: false,
+      value: min,
+      error: `Value must be at least ${min}`,
+    };
+  }
+
+  if (value > max) {
+    return {
+      isValid: false,
+      value: max,
+      error: `Value must be at most ${max}`,
+    };
+  }
+
+  return { isValid: true, value };
+}
+
+/**
+ * Parse and validate an integer within a range.
+ * Combines parseIntSafe and validateNumericRange.
+ *
+ * @param value - The value to parse
+ * @param min - Minimum allowed value
+ * @param max - Maximum allowed value
+ * @param defaultValue - Fallback if parsing fails
+ * @returns The parsed and clamped value
+ *
+ * @example
+ * parseIntInRange('50', 0, 100) // 50
+ * parseIntInRange('150', 0, 100) // 100
+ * parseIntInRange('invalid', 0, 100, 50) // 50
+ */
+export function parseIntInRange(
+  value: string | number | null | undefined,
+  min: number,
+  max: number,
+  defaultValue?: number
+): number {
+  const parsed = parseIntSafe(value, defaultValue ?? min);
+  const { value: clamped } = validateNumericRange(parsed, min, max);
+  return clamped;
+}
+
+/**
+ * Date format validation patterns.
+ */
+const DATE_PATTERNS = {
+  // ISO 8601 date: YYYY-MM-DD
+  ISO_DATE: /^\d{4}-\d{2}-\d{2}$/,
+  // ISO 8601 datetime: YYYY-MM-DDTHH:mm:ss
+  ISO_DATETIME: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+  // US date: MM/DD/YYYY
+  US_DATE: /^\d{1,2}\/\d{1,2}\/\d{4}$/,
+  // Fiscal week: YYFWNN (e.g., 24FW36)
+  FISCAL_WEEK: /^\d{2}FW\d{2}$/,
+};
+
+/**
+ * Validate a date string format.
+ *
+ * @param value - The date string to validate
+ * @param format - The expected format (default: 'ISO_DATE')
+ * @returns Validation result with parsed Date if valid
+ *
+ * @example
+ * validateDateFormat('2024-12-15') // { isValid: true, date: Date, value: '2024-12-15' }
+ * validateDateFormat('invalid') // { isValid: false, error: '...' }
+ * validateDateFormat('12/15/2024', 'US_DATE') // { isValid: true, ... }
+ */
+export function validateDateFormat(
+  value: string | null | undefined,
+  format: keyof typeof DATE_PATTERNS = 'ISO_DATE'
+): { isValid: boolean; date?: Date; value?: string; error?: string } {
+  if (!value || typeof value !== 'string') {
+    return {
+      isValid: false,
+      error: 'Date value is required',
+    };
+  }
+
+  const trimmed = value.trim();
+  const pattern = DATE_PATTERNS[format];
+
+  if (!pattern.test(trimmed)) {
+    return {
+      isValid: false,
+      error: `Invalid date format. Expected ${format} format.`,
+    };
+  }
+
+  // Parse and validate the date is real (e.g., not 2024-02-30)
+  let date: Date;
+  let expectedYear: number;
+  let expectedMonth: number;
+  let expectedDay: number;
+
+  switch (format) {
+    case 'ISO_DATE':
+    case 'ISO_DATETIME': {
+      // Parse components for validation
+      const parts = trimmed.split(/[-T]/);
+      expectedYear = parseInt(parts[0], 10);
+      expectedMonth = parseInt(parts[1], 10);
+      expectedDay = parseInt(parts[2], 10);
+      date = new Date(expectedYear, expectedMonth - 1, expectedDay);
+      break;
+    }
+    case 'US_DATE': {
+      const [month, day, year] = trimmed.split('/').map((n) => parseInt(n, 10));
+      expectedYear = year;
+      expectedMonth = month;
+      expectedDay = day;
+      date = new Date(year, month - 1, day);
+      break;
+    }
+    case 'FISCAL_WEEK':
+      // Fiscal week doesn't convert to a specific date easily
+      return { isValid: true, value: trimmed };
+    default:
+      date = new Date(trimmed);
+      expectedYear = date.getFullYear();
+      expectedMonth = date.getMonth() + 1;
+      expectedDay = date.getDate();
+  }
+
+  if (Number.isNaN(date.getTime())) {
+    return {
+      isValid: false,
+      error: 'Invalid date value',
+    };
+  }
+
+  // Verify the date components match (catches invalid dates like Feb 30)
+  if (
+    date.getFullYear() !== expectedYear ||
+    date.getMonth() + 1 !== expectedMonth ||
+    date.getDate() !== expectedDay
+  ) {
+    return {
+      isValid: false,
+      error: 'Invalid date value (date does not exist)',
+    };
+  }
+
+  return { isValid: true, date, value: trimmed };
+}
+
+/**
+ * Validate a date range (start date before end date).
+ *
+ * @param startDate - Start date string
+ * @param endDate - End date string
+ * @returns Validation result
+ */
+export function validateDateRange(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined
+): { isValid: boolean; error?: string } {
+  const startValidation = validateDateFormat(startDate);
+  if (!startValidation.isValid) {
+    return { isValid: false, error: `Start date: ${startValidation.error}` };
+  }
+
+  const endValidation = validateDateFormat(endDate);
+  if (!endValidation.isValid) {
+    return { isValid: false, error: `End date: ${endValidation.error}` };
+  }
+
+  if (startValidation.date && endValidation.date) {
+    if (startValidation.date > endValidation.date) {
+      return {
+        isValid: false,
+        error: 'Start date must be before or equal to end date',
+      };
+    }
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate an email address format.
+ *
+ * @param value - The email to validate
+ * @returns Validation result
+ */
+export function validateEmail(
+  value: string | null | undefined
+): { isValid: boolean; error?: string } {
+  if (!value || typeof value !== 'string') {
+    return { isValid: false, error: 'Email is required' };
+  }
+
+  const trimmed = value.trim();
+  // Basic email pattern - not overly strict
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  if (!emailPattern.test(trimmed)) {
+    return { isValid: false, error: 'Invalid email format' };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate that a string is not empty after trimming.
+ *
+ * @param value - The string to validate
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateRequired(
+  value: string | null | undefined,
+  fieldName: string = 'Field'
+): { isValid: boolean; error?: string } {
+  if (!value || (typeof value === 'string' && value.trim() === '')) {
+    return { isValid: false, error: `${fieldName} is required` };
+  }
+  return { isValid: true };
+}
+
+/**
+ * Validate string length constraints.
+ *
+ * @param value - The string to validate
+ * @param minLength - Minimum length (default: 0)
+ * @param maxLength - Maximum length (default: Infinity)
+ * @returns Validation result
+ */
+export function validateStringLength(
+  value: string | null | undefined,
+  minLength: number = 0,
+  maxLength: number = Infinity
+): { isValid: boolean; error?: string } {
+  const length = (value || '').length;
+
+  if (length < minLength) {
+    return {
+      isValid: false,
+      error: `Must be at least ${minLength} characters`,
+    };
+  }
+
+  if (length > maxLength) {
+    return {
+      isValid: false,
+      error: `Must be at most ${maxLength} characters`,
+    };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate an enum value against allowed values.
+ *
+ * @param value - The value to validate
+ * @param allowedValues - Array of allowed values
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateEnum<T extends string | number>(
+  value: T | null | undefined,
+  allowedValues: readonly T[],
+  fieldName: string = 'Value'
+): { isValid: boolean; error?: string } {
+  if (value === null || value === undefined) {
+    return { isValid: false, error: `${fieldName} is required` };
+  }
+
+  if (!allowedValues.includes(value)) {
+    return {
+      isValid: false,
+      error: `${fieldName} must be one of: ${allowedValues.join(', ')}`,
+    };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Common validation constants for the application.
+ */
+export const VALIDATION_CONSTANTS = {
+  // Allocation percentages
+  MIN_ALLOCATION: 0,
+  MAX_ALLOCATION: 100,
+  DEFAULT_ALLOCATION: 50,
+
+  // Work hours
+  MIN_HOURS_PER_DAY: 0,
+  MAX_HOURS_PER_DAY: 24,
+  DEFAULT_HOURS_PER_DAY: 8,
+
+  // Project priority
+  MIN_PRIORITY: 1,
+  MAX_PRIORITY: 5,
+  DEFAULT_PRIORITY: 3,
+
+  // Proficiency level
+  MIN_PROFICIENCY: 1,
+  MAX_PROFICIENCY: 5,
+  DEFAULT_PROFICIENCY: 3,
+
+  // Pagination
+  MIN_PAGE: 1,
+  DEFAULT_PAGE: 1,
+  MIN_PAGE_SIZE: 1,
+  MAX_PAGE_SIZE: 1000,
+  DEFAULT_PAGE_SIZE: 50,
+
+  // Lag days for dependencies
+  MIN_LAG_DAYS: -365,
+  MAX_LAG_DAYS: 365,
+  DEFAULT_LAG_DAYS: 0,
+} as const;
+
+/**
+ * Helper to parse allocation percentage with validation.
+ */
+export function parseAllocation(
+  value: string | number | null | undefined
+): number {
+  return parseIntInRange(
+    value,
+    VALIDATION_CONSTANTS.MIN_ALLOCATION,
+    VALIDATION_CONSTANTS.MAX_ALLOCATION,
+    VALIDATION_CONSTANTS.DEFAULT_ALLOCATION
+  );
+}
+
+/**
+ * Helper to parse priority with validation.
+ */
+export function parsePriority(
+  value: string | number | null | undefined
+): number {
+  return parseIntInRange(
+    value,
+    VALIDATION_CONSTANTS.MIN_PRIORITY,
+    VALIDATION_CONSTANTS.MAX_PRIORITY,
+    VALIDATION_CONSTANTS.DEFAULT_PRIORITY
+  );
+}
+
+/**
+ * Helper to parse hours per day with validation.
+ */
+export function parseHoursPerDay(
+  value: string | number | null | undefined
+): number {
+  return parseIntInRange(
+    value,
+    VALIDATION_CONSTANTS.MIN_HOURS_PER_DAY,
+    VALIDATION_CONSTANTS.MAX_HOURS_PER_DAY,
+    VALIDATION_CONSTANTS.DEFAULT_HOURS_PER_DAY
+  );
+}
+
+/**
+ * Helper to parse pagination parameters.
+ */
+export function parsePagination(
+  page: string | number | null | undefined,
+  limit: string | number | null | undefined
+): { page: number; limit: number } {
+  return {
+    page: parseIntInRange(
+      page,
+      VALIDATION_CONSTANTS.MIN_PAGE,
+      Infinity,
+      VALIDATION_CONSTANTS.DEFAULT_PAGE
+    ),
+    limit: parseIntInRange(
+      limit,
+      VALIDATION_CONSTANTS.MIN_PAGE_SIZE,
+      VALIDATION_CONSTANTS.MAX_PAGE_SIZE,
+      VALIDATION_CONSTANTS.DEFAULT_PAGE_SIZE
+    ),
+  };
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,128 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default tseslint.config(
+  // Ignore patterns
+  {
+    ignores: [
+      'dist/**',
+      'dist-electron/**',
+      'node_modules/**',
+      '*.config.js',
+      '*.config.cjs',
+      '*.config.mjs',
+      '*.config.ts',
+      'coverage/**',
+      'build/**',
+      '**/*.backup',
+      '**/*.d.ts'
+    ]
+  },
+
+  // Base JS/TS config
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+
+  // Global relaxed rules for existing codebase
+  {
+    rules: {
+      // IMPORTANT: Enforce radix parameter for parseInt - this is the primary rule
+      'radix': 'error',
+
+      // Relaxed rules for existing codebase (warnings, not errors)
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': ['warn', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_'
+      }],
+      '@typescript-eslint/no-empty-object-type': 'warn',
+      '@typescript-eslint/no-this-alias': 'warn',
+      '@typescript-eslint/no-namespace': 'warn',
+      '@typescript-eslint/no-require-imports': 'warn',
+      'no-console': 'off',
+      'no-case-declarations': 'warn',
+      'no-empty': 'warn',
+      'no-useless-catch': 'warn',
+      'prefer-const': 'warn'
+    }
+  },
+
+  // Client (React) specific config
+  {
+    files: ['client/src/**/*.{ts,tsx}'],
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh
+    },
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.es2022
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      }
+    },
+    rules: {
+      // React hooks rules
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true }
+      ]
+    }
+  },
+
+  // Server specific config
+  {
+    files: ['src/server/**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+        ...globals.es2022
+      }
+    }
+  },
+
+  // Electron specific config
+  {
+    files: ['src/electron/**/*.{js,cjs}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'script',
+      globals: {
+        ...globals.node,
+        ...globals.browser
+      }
+    },
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off'
+    }
+  },
+
+  // Test files config
+  {
+    files: ['**/*.test.{ts,tsx}', '**/__tests__/**/*.{ts,tsx}', 'tests/**/*.{ts,tsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+        ...globals.node
+      }
+    },
+    rules: {
+      // Allow any in tests
+      '@typescript-eslint/no-explicit-any': 'off',
+      // Allow require() in tests for dynamic imports
+      '@typescript-eslint/no-require-imports': 'off'
+    }
+  }
+);

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test:scenarios:e2e": "playwright test --config=playwright.scenario.config.ts",
     "test:scenarios:corruption": "playwright test --config=playwright.scenario.config.ts --project=scenario-corruption-tests",
     "test:scenarios:all": "./scripts/test-scenario-system.sh",
-    "lint": "eslint src --ext .ts,.tsx",
+    "lint": "eslint src client/src --ext .ts,.tsx,.js,.cjs",
     "typecheck": "tsc --noEmit",
     "typecheck:shared": "cd shared && tsc --noEmit",
     "db:init": "tsx src/server/database/init.ts",

--- a/src/electron/settings-window.js
+++ b/src/electron/settings-window.js
@@ -95,10 +95,10 @@ async function saveSettings() {
             ...config.database,
             autoBackup: document.getElementById('autoBackup').checked,
             backupInterval: document.getElementById('backupInterval').value,
-            backupRetention: parseInt(document.getElementById('backupRetention').value)
+            backupRetention: parseInt(document.getElementById('backupRetention').value, 10)
         },
         server: {
-            port: parseInt(document.getElementById('serverPort').value),
+            port: parseInt(document.getElementById('serverPort').value, 10),
             host: document.getElementById('serverHost').value,
             requireAuth: document.getElementById('requireAuth').checked,
             enableHttps: document.getElementById('enableHttps').checked
@@ -109,7 +109,7 @@ async function saveSettings() {
         advanced: {
             logLevel: document.getElementById('logLevel').value,
             logLocation: document.getElementById('logLocation').value,
-            maxConnections: parseInt(document.getElementById('connectionPool').value),
+            maxConnections: parseInt(document.getElementById('connectionPool').value, 10),
             enableCache: document.getElementById('enableCache').checked,
             compressResponses: document.getElementById('compressResponses').checked,
             enableDevTools: document.getElementById('enableDevTools').checked

--- a/src/electron/setup-wizard.js
+++ b/src/electron/setup-wizard.js
@@ -105,7 +105,7 @@ function validateCurrentStep() {
             break;
             
         case 'server':
-            const port = parseInt(document.getElementById('serverPort').value);
+            const port = parseInt(document.getElementById('serverPort').value, 10);
             if (isNaN(port) || port < 1024 || port > 65535) {
                 showError('Please enter a valid port number between 1024 and 65535');
                 return false;
@@ -125,18 +125,18 @@ function saveCurrentStep() {
             config.database.filename = document.getElementById('dbName').value.trim();
             config.database.autoBackup = document.getElementById('autoBackup').checked;
             config.database.backupInterval = document.getElementById('backupInterval').value;
-            config.database.backupRetention = parseInt(document.getElementById('backupRetention').value);
+            config.database.backupRetention = parseInt(document.getElementById('backupRetention').value, 10);
             break;
             
         case 'server':
-            config.server.port = parseInt(document.getElementById('serverPort').value);
+            config.server.port = parseInt(document.getElementById('serverPort').value, 10);
             config.server.host = document.getElementById('serverHost').value;
             config.server.requireAuth = document.getElementById('requireAuth').checked;
             break;
             
         case 'advanced':
             config.advanced.logLevel = document.getElementById('logLevel').value;
-            config.advanced.maxConnections = parseInt(document.getElementById('maxConnections').value);
+            config.advanced.maxConnections = parseInt(document.getElementById('maxConnections').value, 10);
             config.advanced.enableCache = document.getElementById('enableCache').checked;
             config.advanced.compressResponses = document.getElementById('compressResponses').checked;
             config.advanced.enableDevTools = document.getElementById('devTools').checked;

--- a/src/server/api/controllers/AssignmentsController.ts
+++ b/src/server/api/controllers/AssignmentsController.ts
@@ -25,8 +25,8 @@ export class AssignmentsController extends BaseController {
     super({ enableLogging: true }, { container });
   }
   getAll = this.asyncHandler(async (req: RequestWithLogging, res: Response) => {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 50;
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
     const filters = {
       project_id: req.query.project_id,
       person_id: req.query.person_id,

--- a/src/server/api/controllers/AuditController.ts
+++ b/src/server/api/controllers/AuditController.ts
@@ -19,7 +19,7 @@ export class AuditController extends BaseController {
   getAuditHistory = async (req: Request, res: Response): Promise<void> => {
     await this.executeQuery(async () => {
       const { tableName, recordId } = req.params;
-      const limit = req.query.limit ? parseInt(req.query.limit as string) : undefined;
+      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
 
       if (!tableName || !recordId) {
         return res.status(400).json({
@@ -44,8 +44,8 @@ export class AuditController extends BaseController {
   getRecentChanges = async (req: Request, res: Response): Promise<void> => {
     await this.executeQuery(async () => {
       const changedBy = req.query.changedBy as string;
-      const limit = parseInt((req.query.limit as string) || '50');
-      const offset = parseInt((req.query.offset as string) || '0');
+      const limit = parseInt((req.query.limit as string) || '50', 10);
+      const offset = parseInt((req.query.offset as string) || '0', 10);
 
       const changes = await this.auditService.getRecentChanges(changedBy, limit, offset);
       
@@ -72,8 +72,8 @@ export class AuditController extends BaseController {
         requestId: req.query.requestId as string,
         fromDate: req.query.fromDate ? new Date(req.query.fromDate as string) : undefined,
         toDate: req.query.toDate ? new Date(req.query.toDate as string) : undefined,
-        limit: parseInt((req.query.limit as string) || '50'),
-        offset: parseInt((req.query.offset as string) || '0')
+        limit: parseInt((req.query.limit as string) || '50', 10),
+        offset: parseInt((req.query.offset as string) || '0', 10)
       };
 
       // Remove undefined values
@@ -161,7 +161,7 @@ export class AuditController extends BaseController {
         });
       }
 
-      const countNum = parseInt(count);
+      const countNum = parseInt(count, 10);
       if (isNaN(countNum) || countNum <= 0 || countNum > 100) {
         return res.status(400).json({
           error: 'count must be a number between 1 and 100'

--- a/src/server/api/controllers/AvailabilityController.ts
+++ b/src/server/api/controllers/AvailabilityController.ts
@@ -7,8 +7,8 @@ export class AvailabilityController extends BaseController {
     super({ enableAudit: true }, { container });
   }
   async getAll(req: Request, res: Response) {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 50;
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
     const filters = {
       person_id: req.query.person_id,
       override_type: req.query.override_type,

--- a/src/server/api/controllers/ImportController.ts
+++ b/src/server/api/controllers/ImportController.ts
@@ -57,7 +57,7 @@ export class ImportController extends BaseController {
       }
     },
     limits: {
-      fileSize: parseInt(process.env.MAX_FILE_SIZE || '52428800') // 50MB default
+      fileSize: parseInt(process.env.MAX_FILE_SIZE || '52428800', 10) // 50MB default
     }
   });
 
@@ -143,10 +143,10 @@ export class ImportController extends BaseController {
         validateDuplicates: req.body.validateDuplicates === 'true' || req.body.validateDuplicates === true || savedSettings.validateDuplicates,
         autoCreateMissingRoles: req.body.autoCreateMissingRoles === 'true' || req.body.autoCreateMissingRoles === true || savedSettings.autoCreateMissingRoles,
         autoCreateMissingLocations: req.body.autoCreateMissingLocations === 'true' || req.body.autoCreateMissingLocations === true || savedSettings.autoCreateMissingLocations,
-        defaultProjectPriority: req.body.defaultProjectPriority ? parseInt(req.body.defaultProjectPriority) : savedSettings.defaultProjectPriority,
+        defaultProjectPriority: req.body.defaultProjectPriority ? parseInt(req.body.defaultProjectPriority, 10) : savedSettings.defaultProjectPriority,
         dateFormat: req.body.dateFormat || savedSettings.dateFormat
       };
-      
+
       console.log(`Starting Excel import from: ${req.file.path}`);
       console.log(`Import options:`, importOptions);
       
@@ -315,13 +315,13 @@ export class ImportController extends BaseController {
 
   async getImportHistory(req: Request, res: Response) {
     try {
-      const page = parseInt(req.query.page as string) || 1;
-      const limit = parseInt(req.query.limit as string) || 50;
+      const page = parseInt(req.query.page as string, 10) || 1;
+      const limit = parseInt(req.query.limit as string, 10) || 50;
       const offset = (page - 1) * limit;
-      
+
       // Get total count
       const totalCountResult = await this.db('import_history').count('* as count').first();
-      const totalCount = parseInt(totalCountResult.count);
+      const totalCount = parseInt(totalCountResult.count, 10);
       
       // Get import history records
       const imports = await this.db('import_history')
@@ -583,7 +583,7 @@ export class ImportController extends BaseController {
         validateDuplicates: req.body.validateDuplicates === 'true' || req.body.validateDuplicates === true || savedSettings.validateDuplicates,
         autoCreateMissingRoles: req.body.autoCreateMissingRoles === 'true' || req.body.autoCreateMissingRoles === true || savedSettings.autoCreateMissingRoles,
         autoCreateMissingLocations: req.body.autoCreateMissingLocations === 'true' || req.body.autoCreateMissingLocations === true || savedSettings.autoCreateMissingLocations,
-        defaultProjectPriority: req.body.defaultProjectPriority ? parseInt(req.body.defaultProjectPriority) : savedSettings.defaultProjectPriority,
+        defaultProjectPriority: req.body.defaultProjectPriority ? parseInt(req.body.defaultProjectPriority, 10) : savedSettings.defaultProjectPriority,
         dateFormat: req.body.dateFormat || savedSettings.dateFormat,
         dryRun: true // Force dry-run mode for analysis
       };

--- a/src/server/api/controllers/NotificationsController.ts
+++ b/src/server/api/controllers/NotificationsController.ts
@@ -146,8 +146,8 @@ export class NotificationsController {
         )
         .join('people', 'notification_history.user_id', 'people.id')
         .orderBy('notification_history.sent_at', 'desc')
-        .limit(parseInt(limit as string))
-        .offset(parseInt(offset as string));
+        .limit(parseInt(limit as string, 10))
+        .offset(parseInt(offset as string, 10));
 
       if (userId) {
         query = query.where('notification_history.user_id', userId);
@@ -247,7 +247,7 @@ export class NotificationsController {
       const { days = 30 } = req.query;
 
       const startDate = new Date();
-      startDate.setDate(startDate.getDate() - parseInt(days as string));
+      startDate.setDate(startDate.getDate() - parseInt(days as string, 10));
 
       let baseQuery = this.db('notification_history')
         .where('sent_at', '>=', startDate);

--- a/src/server/api/controllers/PeopleController.ts
+++ b/src/server/api/controllers/PeopleController.ts
@@ -7,8 +7,8 @@ export class PeopleController extends BaseController {
     super({ enableAudit: true }, { container });
   }
   async getAll(req: Request, res: Response) {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 50;
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
     const filters = {
       primary_role_id: req.query.primary_role_id, // Still allow filtering by role_id for API compatibility
       supervisor_id: req.query.supervisor_id,

--- a/src/server/api/controllers/ProjectPhasesController.ts
+++ b/src/server/api/controllers/ProjectPhasesController.ts
@@ -12,8 +12,8 @@ export class ProjectPhasesController extends BaseController {
     super({ enableLogging: true }, { container });
   }
   getAll = this.asyncHandler(async (req: RequestWithLogging, res: Response) => {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 50;
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
     const result = await this.executeQuery(async () => {
       let query = this.db('project_phases_timeline')
         .join('projects', 'project_phases_timeline.project_id', 'projects.id')

--- a/src/server/api/controllers/ProjectSubTypesController.ts
+++ b/src/server/api/controllers/ProjectSubTypesController.ts
@@ -302,7 +302,7 @@ export class ProjectSubTypesController {
         .count('* as count')
         .first();
 
-      if (projectCount && parseInt(projectCount.count as string) > 0) {
+      if (projectCount && parseInt(projectCount.count as string, 10) > 0) {
         return res.status(409).json({
           success: false,
           error: 'Cannot delete project sub-type that is being used by projects'

--- a/src/server/api/controllers/ProjectTypesController.ts
+++ b/src/server/api/controllers/ProjectTypesController.ts
@@ -9,8 +9,8 @@ export class ProjectTypesController extends BaseController {
   }
 
   async getAll(req: Request, res: Response) {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 50;
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
     const include_inactive = req.query.include_inactive === 'true';
 
     const result = await this.executeQuery(async () => {
@@ -30,7 +30,7 @@ export class ProjectTypesController extends BaseController {
         .groupBy('project_type_id');
 
       const countMap = subTypeCounts.reduce((acc: any, item: any) => {
-        acc[item.project_type_id] = parseInt(item.sub_type_count);
+        acc[item.project_type_id] = parseInt(item.sub_type_count, 10);
         return acc;
       }, {});
 

--- a/src/server/api/controllers/ProjectsController.ts
+++ b/src/server/api/controllers/ProjectsController.ts
@@ -166,8 +166,8 @@ export class ProjectsController extends BaseController {
   }
 
   getAll = this.asyncHandler(async (req: RequestWithLogging, res: Response) => {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 50;
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
     const filters = {
       location_id: req.query.location_id,
       project_type_id: req.query.project_type_id,

--- a/src/server/api/controllers/ResourceTemplatesController.ts
+++ b/src/server/api/controllers/ResourceTemplatesController.ts
@@ -8,8 +8,8 @@ export class ResourceTemplatesController extends BaseController {
   }
 
   async getAll(req: Request, res: Response) {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 50;
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
     const filters = {
       project_type_id: req.query.project_type_id,
       phase_id: req.query.phase_id,

--- a/src/server/api/controllers/SimpleController.ts
+++ b/src/server/api/controllers/SimpleController.ts
@@ -8,8 +8,8 @@ export class SimpleController extends BaseController {
   }
 
   async getAll(req: Request, res: Response) {
-    const page = parseInt(req.query.page as string) || 1;
-    const limit = parseInt(req.query.limit as string) || 50;
+    const page = parseInt(req.query.page as string, 10) || 1;
+    const limit = parseInt(req.query.limit as string, 10) || 50;
 
     const result = await this.executeQuery(async () => {
       let query = this.db(this.tableName).select('*');

--- a/src/server/database/index.ts
+++ b/src/server/database/index.ts
@@ -163,7 +163,7 @@ export async function backupDatabase(): Promise<string> {
   fs.copyFileSync(sourceFile, backupFile);
   
   // Clean old backups
-  const retentionDays = parseInt(process.env.DB_BACKUP_RETENTION_DAYS || '30');
+  const retentionDays = parseInt(process.env.DB_BACKUP_RETENTION_DAYS || '30', 10);
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
   

--- a/src/server/services/EmailService.ts
+++ b/src/server/services/EmailService.ts
@@ -62,7 +62,7 @@ export class EmailService {
     // Load email configuration from environment variables
     this.config = {
       host: process.env.SMTP_HOST || 'localhost',
-      port: parseInt(process.env.SMTP_PORT || '587'),
+      port: parseInt(process.env.SMTP_PORT || '587', 10),
       secure: process.env.SMTP_SECURE === 'true',
       auth: {
         user: process.env.SMTP_USER || '',

--- a/src/server/services/import/ExcelImporter.ts
+++ b/src/server/services/import/ExcelImporter.ts
@@ -603,7 +603,7 @@ export class ExcelImporter {
           name: projectName,
           project_type_id: projectTypeId,
           location_id: locationId,
-          priority: parseInt(values[expectedColumns.priority]?.toString()) || 3,
+          priority: parseInt(values[expectedColumns.priority]?.toString(), 10) || 3,
           description: values[expectedColumns.description]?.toString() || '',
           include_in_demand: 1,
           aspiration_start: this.parseDate(values[expectedColumns.aspirationStart]),

--- a/src/server/services/import/ExcelImporterV2.ts
+++ b/src/server/services/import/ExcelImporterV2.ts
@@ -796,7 +796,7 @@ export class ExcelImporterV2 {
           name: projectName,
           project_type_id: projectTypeRecord.id,
           location_id: locationId,
-          priority: parseInt(priority || '3') || 3,
+          priority: parseInt(priority || '3', 10) || 3,
           include_in_demand: includeInDemand === 'Y' ? 1 : 0,
           created_at: new Date(),
           updated_at: new Date()
@@ -1302,10 +1302,10 @@ export class ExcelImporterV2 {
       result.warnings.push(...plannersResult.errors);
 
       // Count imported locations
-      result.imported.locations = await this.db('locations').count('* as count').first().then(r => parseInt(String(r?.count || '0')));
-      
+      result.imported.locations = await this.db('locations').count('* as count').first().then(r => parseInt(String(r?.count || '0'), 10));
+
       // Count availability overrides
-      result.imported.availabilityOverrides = await this.db('person_availability_overrides').count('* as count').first().then(r => parseInt(String(r?.count || '0')));
+      result.imported.availabilityOverrides = await this.db('person_availability_overrides').count('* as count').first().then(r => parseInt(String(r?.count || '0'), 10));
 
       // Collect all structured errors and warnings
       const errorSummary = errorCollector.toJSON();

--- a/src/server/services/logging/config.ts
+++ b/src/server/services/logging/config.ts
@@ -39,8 +39,8 @@ export function getLoggerConfig(): LoggerConfig {
     enableConsole: !isTest || process.env.ENABLE_TEST_LOGS === 'true',
     enableFile: isProduction,
     logDirectory: process.env.LOG_DIRECTORY || '/tmp/capacinator-logs',
-    maxFileSize: parseInt(process.env.LOG_MAX_FILE_SIZE || '10485760'), // 10MB
-    maxFiles: parseInt(process.env.LOG_MAX_FILES || '10'),
+    maxFileSize: parseInt(process.env.LOG_MAX_FILE_SIZE || '10485760', 10), // 10MB
+    maxFiles: parseInt(process.env.LOG_MAX_FILES || '10', 10),
     enableStructuredLogs: process.env.LOG_FORMAT === 'json' || isProduction,
     redactedFields: [
       'password',

--- a/src/server/utils/dateValidation.ts
+++ b/src/server/utils/dateValidation.ts
@@ -30,7 +30,7 @@ export function validateAndParseDate(dateInput: any, fieldName: string): DateVal
     } 
     // Check if it's a numeric string (timestamp)
     else if (/^\d+$/.test(dateInput)) {
-      parsedDate = new Date(parseInt(dateInput));
+      parsedDate = new Date(parseInt(dateInput, 10));
     } 
     // Try to parse other string formats
     else {

--- a/src/server/utils/fiscalWeek.ts
+++ b/src/server/utils/fiscalWeek.ts
@@ -11,8 +11,8 @@ export function fiscalWeekToDate(fiscalWeek: string): Date | null {
   const match = fiscalWeek.match(/^(\d{2})FW(\d{2})$/);
   if (!match) return null;
   
-  const year = parseInt('20' + match[1]);
-  const week = parseInt(match[2]);
+  const year = parseInt('20' + match[1], 10);
+  const week = parseInt(match[2], 10);
   
   // Calculate the date for the first day of the fiscal week
   // Assuming fiscal week starts on Monday

--- a/src/server/utils/validation.ts
+++ b/src/server/utils/validation.ts
@@ -1,0 +1,427 @@
+/**
+ * Server-Side Input Validation Utilities
+ *
+ * Provides safe parsing and validation functions for API inputs
+ * to prevent bugs from improper type coercion and invalid data.
+ */
+
+/**
+ * Safely parse an integer with proper radix and fallback handling.
+ * Always uses radix 10 to avoid octal/hex interpretation issues.
+ *
+ * @param value - The value to parse (string, number, null, or undefined)
+ * @param defaultValue - The fallback value if parsing fails
+ * @returns The parsed integer or the default value
+ */
+export function parseIntSafe(
+  value: string | number | null | undefined,
+  defaultValue: number = 0
+): number {
+  if (value === null || value === undefined || value === '') {
+    return defaultValue;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? Math.floor(value) : defaultValue;
+  }
+
+  const trimmed = String(value).trim();
+  if (trimmed === '') {
+    return defaultValue;
+  }
+
+  const parsed = parseInt(trimmed, 10);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+/**
+ * Safely parse a float with fallback handling.
+ *
+ * @param value - The value to parse
+ * @param defaultValue - The fallback value if parsing fails
+ * @returns The parsed float or the default value
+ */
+export function parseFloatSafe(
+  value: string | number | null | undefined,
+  defaultValue: number = 0
+): number {
+  if (value === null || value === undefined || value === '') {
+    return defaultValue;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : defaultValue;
+  }
+
+  const trimmed = String(value).trim();
+  if (trimmed === '') {
+    return defaultValue;
+  }
+
+  const parsed = parseFloat(trimmed);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+/**
+ * Parse and clamp an integer within a range.
+ *
+ * @param value - The value to parse
+ * @param min - Minimum allowed value
+ * @param max - Maximum allowed value
+ * @param defaultValue - Fallback if parsing fails
+ * @returns The parsed and clamped value
+ */
+export function parseIntInRange(
+  value: string | number | null | undefined,
+  min: number,
+  max: number,
+  defaultValue?: number
+): number {
+  const parsed = parseIntSafe(value, defaultValue ?? min);
+  return Math.max(min, Math.min(max, parsed));
+}
+
+/**
+ * Parse pagination parameters from request query.
+ *
+ * @param page - Page number (1-indexed)
+ * @param limit - Number of items per page
+ * @returns Parsed and validated pagination parameters
+ */
+export function parsePagination(
+  page: string | number | null | undefined,
+  limit: string | number | null | undefined
+): { page: number; limit: number; offset: number } {
+  const parsedPage = parseIntInRange(page, 1, Number.MAX_SAFE_INTEGER, 1);
+  const parsedLimit = parseIntInRange(limit, 1, 1000, 50);
+  const offset = (parsedPage - 1) * parsedLimit;
+
+  return {
+    page: parsedPage,
+    limit: parsedLimit,
+    offset,
+  };
+}
+
+/**
+ * Validate that a value is a valid positive integer.
+ *
+ * @param value - The value to validate
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validatePositiveInt(
+  value: unknown,
+  fieldName: string = 'Value'
+): { isValid: boolean; value: number; error?: string } {
+  const parsed = parseIntSafe(value as string | number | null | undefined, -1);
+
+  if (parsed < 0) {
+    return {
+      isValid: false,
+      value: 0,
+      error: `${fieldName} must be a valid positive integer`,
+    };
+  }
+
+  return { isValid: true, value: parsed };
+}
+
+/**
+ * Validate a numeric range.
+ *
+ * @param value - The value to validate
+ * @param min - Minimum allowed value
+ * @param max - Maximum allowed value
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateNumericRange(
+  value: number,
+  min: number,
+  max: number,
+  fieldName: string = 'Value'
+): { isValid: boolean; error?: string } {
+  if (!Number.isFinite(value)) {
+    return {
+      isValid: false,
+      error: `${fieldName} must be a valid number`,
+    };
+  }
+
+  if (value < min) {
+    return {
+      isValid: false,
+      error: `${fieldName} must be at least ${min}`,
+    };
+  }
+
+  if (value > max) {
+    return {
+      isValid: false,
+      error: `${fieldName} must be at most ${max}`,
+    };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validate a required string field.
+ *
+ * @param value - The value to validate
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateRequiredString(
+  value: unknown,
+  fieldName: string = 'Field'
+): { isValid: boolean; value: string; error?: string } {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return {
+      isValid: false,
+      value: '',
+      error: `${fieldName} is required`,
+    };
+  }
+
+  return { isValid: true, value: value.trim() };
+}
+
+/**
+ * Validate an optional string field with max length.
+ *
+ * @param value - The value to validate
+ * @param maxLength - Maximum allowed length
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateOptionalString(
+  value: unknown,
+  maxLength: number = 1000,
+  fieldName: string = 'Field'
+): { isValid: boolean; value: string | null; error?: string } {
+  if (value === null || value === undefined) {
+    return { isValid: true, value: null };
+  }
+
+  if (typeof value !== 'string') {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} must be a string`,
+    };
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length > maxLength) {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} must be at most ${maxLength} characters`,
+    };
+  }
+
+  return { isValid: true, value: trimmed || null };
+}
+
+/**
+ * Validate an enum value.
+ *
+ * @param value - The value to validate
+ * @param allowedValues - Array of allowed values
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateEnum<T extends string | number>(
+  value: unknown,
+  allowedValues: readonly T[],
+  fieldName: string = 'Value'
+): { isValid: boolean; value: T | null; error?: string } {
+  if (value === null || value === undefined) {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} is required`,
+    };
+  }
+
+  if (!allowedValues.includes(value as T)) {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} must be one of: ${allowedValues.join(', ')}`,
+    };
+  }
+
+  return { isValid: true, value: value as T };
+}
+
+/**
+ * Validate an ISO date string.
+ *
+ * @param value - The date string to validate
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateISODate(
+  value: unknown,
+  fieldName: string = 'Date'
+): { isValid: boolean; value: string | null; error?: string } {
+  if (value === null || value === undefined) {
+    return { isValid: true, value: null };
+  }
+
+  if (typeof value !== 'string') {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} must be a string`,
+    };
+  }
+
+  const trimmed = value.trim();
+
+  // Check ISO date format: YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} must be in YYYY-MM-DD format`,
+    };
+  }
+
+  // Validate the date is real
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} is not a valid date`,
+    };
+  }
+
+  return { isValid: true, value: trimmed };
+}
+
+/**
+ * Validate a UUID string.
+ *
+ * @param value - The UUID to validate
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateUUID(
+  value: unknown,
+  fieldName: string = 'ID'
+): { isValid: boolean; value: string | null; error?: string } {
+  if (value === null || value === undefined) {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} is required`,
+    };
+  }
+
+  if (typeof value !== 'string') {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} must be a string`,
+    };
+  }
+
+  const trimmed = value.trim();
+
+  // UUID v4 pattern (also accepts other versions)
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      trimmed
+    )
+  ) {
+    // Also accept non-UUID IDs that are common in this app
+    if (!/^[a-zA-Z0-9_-]+$/.test(trimmed) || trimmed.length > 100) {
+      return {
+        isValid: false,
+        value: null,
+        error: `${fieldName} must be a valid identifier`,
+      };
+    }
+  }
+
+  return { isValid: true, value: trimmed };
+}
+
+/**
+ * Validate an email address.
+ *
+ * @param value - The email to validate
+ * @param fieldName - Name of the field for error messages
+ * @returns Validation result
+ */
+export function validateEmail(
+  value: unknown,
+  fieldName: string = 'Email'
+): { isValid: boolean; value: string | null; error?: string } {
+  if (value === null || value === undefined) {
+    return { isValid: true, value: null };
+  }
+
+  if (typeof value !== 'string') {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} must be a string`,
+    };
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === '') {
+    return { isValid: true, value: null };
+  }
+
+  // Basic email pattern
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+    return {
+      isValid: false,
+      value: null,
+      error: `${fieldName} must be a valid email address`,
+    };
+  }
+
+  return { isValid: true, value: trimmed };
+}
+
+/**
+ * Common validation constants.
+ */
+export const VALIDATION_CONSTANTS = {
+  // Allocation percentages
+  MIN_ALLOCATION: 0,
+  MAX_ALLOCATION: 100,
+  DEFAULT_ALLOCATION: 50,
+
+  // Work hours
+  MIN_HOURS_PER_DAY: 0,
+  MAX_HOURS_PER_DAY: 24,
+  DEFAULT_HOURS_PER_DAY: 8,
+
+  // Project priority
+  MIN_PRIORITY: 1,
+  MAX_PRIORITY: 5,
+  DEFAULT_PRIORITY: 3,
+
+  // Pagination
+  MIN_PAGE: 1,
+  DEFAULT_PAGE: 1,
+  MIN_PAGE_SIZE: 1,
+  MAX_PAGE_SIZE: 1000,
+  DEFAULT_PAGE_SIZE: 50,
+
+  // File size
+  MAX_FILE_SIZE: 52428800, // 50MB
+
+  // String lengths
+  MAX_NAME_LENGTH: 255,
+  MAX_DESCRIPTION_LENGTH: 2000,
+} as const;


### PR DESCRIPTION
## Summary

- Fix all `parseInt()` calls to include radix parameter (10) across 45+ files to prevent octal interpretation bugs
- Add comprehensive validation utilities for both client and server-side use
- Create ESLint configuration with `radix` rule enforcement to prevent future issues
- Update lint script to cover both `src/` and `client/src/` directories

## Changes

### Client-side Validation Utilities (`client/src/utils/validation.ts`)
- `parseIntSafe` - Safe integer parsing with fallback
- `parseFloatSafe` - Safe float parsing with fallback
- `validateNumericRange` - Validate and clamp numeric values
- `parseIntInRange` - Combined parse and range validation
- `validateDateFormat` - ISO, US, and fiscal week date format validation
- `validateDateRange` - Start/end date range validation
- `validateEmail` - Email format validation
- `validateRequired` - Non-empty string validation
- `validateStringLength` - Min/max length validation
- `validateEnum` - Enum value validation
- Helper functions: `parseAllocation`, `parsePriority`, `parseHoursPerDay`, `parsePagination`
- `VALIDATION_CONSTANTS` with standard min/max/default values

### Server-side Validation Utilities (`src/server/utils/validation.ts`)
- Mirrors client-side functionality for consistent validation

### ESLint Configuration (`eslint.config.js`)
- New flat config format for ESLint 9.x
- `radix` rule set to `error` to enforce parseInt radix parameter
- Pre-existing code quality issues set to `warn` to avoid blocking

### parseInt Fixes (45+ files)
- All `parseInt(value)` calls changed to `parseInt(value, 10)`
- Affects: client pages, modals, components, controllers, electron files

## Test Plan
- [x] All 48 validation utility tests pass
- [x] ESLint passes with 0 errors (1451 warnings are pre-existing)
- [x] TypeScript compilation successful
- [ ] Manual testing of form inputs with leading zeros
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)