### PR TITLE
feat: type test utilities - eliminate any types in e2e helpers (issue #59)

### DIFF
--- a/tests/e2e/helpers/unified-test-data-factory.ts
+++ b/tests/e2e/helpers/unified-test-data-factory.ts
@@ -285,15 +285,22 @@ export class UnifiedTestDataFactory {
           const subTypesResult = await subTypesResponse.json();
           const subTypes = subTypesResult.data || subTypesResult;
 
+          // Define interface for subtype with optional grouping
+          interface SubTypeWithGroup {
+            id?: string;
+            project_type_id?: string;
+            sub_types?: SubTypeWithGroup[];
+          }
+
           // Handle grouped data
-          let flatSubTypes: any[] = [];
+          let flatSubTypes: SubTypeWithGroup[] = [];
           if (Array.isArray(subTypes) && subTypes[0]?.sub_types) {
-            flatSubTypes = subTypes.flatMap((g: any) => g.sub_types || []);
+            flatSubTypes = subTypes.flatMap((g: SubTypeWithGroup) => g.sub_types || []);
           } else if (Array.isArray(subTypes)) {
             flatSubTypes = subTypes;
           }
 
-          const matchingSubType = flatSubTypes.find((st: any) => st.project_type_id === projectTypeId);
+          const matchingSubType = flatSubTypes.find((st: SubTypeWithGroup) => st.project_type_id === projectTypeId);
           if (matchingSubType) {
             projectSubTypeId = matchingSubType.id;
           }


### PR DESCRIPTION
## Summary

- Eliminated 44 `any` type usages from key test utilities
- Added typed interfaces for test entities in `test-data-generator.ts`
- Updated all generator methods with proper parameter and return types  
- Added type-safe API response handling with helper utilities

## Changes

### test-data-generator.ts (35 any → 0)
- Added `TestLocation`, `TestProjectType`, `TestPhase`, `TestRole`, `TestStandardAllocation` interfaces
- Added `ApiResponse<T>` interface and `extractArray<T>()` helper for consistent API response handling
- Updated `TestScenarioData` to use typed arrays instead of `any[]`
- Typed all generator methods: `generateEmployees`, `generateProjects`, `generatePhases`, etc.
- Typed API methods: `createTestProject`, `addProjectPhases`

### test-data-factory.ts (6 any → 0)
- Added `FactoryPerson`, `FactoryProject`, `FactoryAssignment`, `FactoryScenario` interfaces
- Updated all creation methods with proper return types
- Typed `createBulkTestData` and `createScenarioTestData` methods

### unified-test-data-factory.ts (3 any → 0)
- Added `SubTypeWithGroup` interface for grouped data handling
- Replaced `any[]` with properly typed arrays

## Test plan

- [x] TypeScript compilation passes for modified files
- [x] No new TypeScript errors introduced
- [x] Client unit tests pass (pre-existing failures unrelated to changes)
- [x] Test utilities remain backward compatible

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)