### PR TITLE
fix(build): remove missing installer.nsh reference to fix Windows builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
-      "include": "build/installer.nsh",
       "warningsAsErrors": false,
       "perMachine": false
     },


### PR DESCRIPTION
## Problem
Build #10 on main failed during Windows build with error:
```
⨯ cannot find specified resource "build/installer.nsh"
```

The `package.json` nsis configuration references `build/installer.nsh` but this file doesn't exist in the repository.

## Solution
Remove the `include: "build/installer.nsh"` line from the nsis configuration in package.json. The NSIS installer works fine with default configuration - this is an optional customization file.

## Testing
- ✅ Unit tests pass locally
- ✅ Wine 10.0 installed in all 8 Jenkins Docker containers
- ✅ wine64 symlink created for electron-builder compatibility

This PR completes the Windows build setup. Once merged, main builds should successfully create Windows .exe installers.

## Related
- Fixes build #10 failure
- Follows up on PR #121 (Wine installation)