### PR TITLE
fix(tests): exclude dist-electron from Jest snapshot detection

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -123,6 +123,7 @@ module.exports = {
   testPathIgnorePatterns: [
     '/node_modules/',
     '/dist/',
+    '/dist-electron/',
     '/build/',
     '/tests/e2e/',
     '\\.spec\\.ts$'


### PR DESCRIPTION
## Summary
- Fixed CI instability on main branch caused by Jest snapshot detection
- Jest was mistakenly treating Electron's Linux Snap package (`.snap` file) as an obsolete Jest snapshot
- Added `/dist-electron/` to `testPathIgnorePatterns` in jest.config.cjs

## Root Cause
When Electron builds are present locally or on CI, the Linux Snap package at `dist-electron/capacinator_1.0.0_amd64.snap` was being detected by Jest's snapshot matching system. Jest would report "1 snapshot file obsolete" and exit with code 1, marking the build as UNSTABLE even though all tests passed.

## Fix
Added `/dist-electron/` to the `testPathIgnorePatterns` array to prevent Jest from scanning build artifacts for snapshots.

## Verification
- ✅ All unit tests pass locally (53 suites, 1424 tests)
- ✅ Exit code 0 (no failures or warnings)
- ✅ No obsolete snapshot warnings

## Test Plan
- [x] Run `npm run test:unit` locally - passes with exit code 0
- [ ] Verify Jenkins CI build passes on main branch
- [ ] Confirm no UNSTABLE status on future builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)